### PR TITLE
feat(api): remove static route

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -1,6 +1,5 @@
 import cors from "cors";
 import express from "express";
-import path from "path";
 
 import { logger } from "./logger.js";
 import health from "./src/shared/health/routes.js";
@@ -10,7 +9,6 @@ const server = express();
 
 server.use(cors());
 server.use(express.json());
-server.use(express.static(path.join(process.cwd(), "dist")));
 server.use(swaggerRoute);
 server.use((req, res, next) => {
   res.on("finish", () => {


### PR DESCRIPTION
This pull request makes a minor update to the `api/server.js` file by removing the use of the `path` module and the middleware that served static files from the `dist` directory. These changes simplify the server setup and remove unnecessary dependencies.

* Removed the import of the `path` module from `api/server.js`.
* Removed the line that served static files from the `dist` directory using `express.static`.