### PR TITLE
tech(api): create JWT token service

### DIFF
--- a/api/db/migrations/20250925085355_add-isActive-column-to-users-table.js
+++ b/api/db/migrations/20250925085355_add-isActive-column-to-users-table.js
@@ -1,0 +1,23 @@
+const TABLE_NAME = "users";
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+async function up(knex) {
+  await knex.schema.alterTable(TABLE_NAME, (table) => {
+    table.boolean("isActive").defaultTo(true).notNullable();
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+async function down(knex) {
+  await knex.schema.alterTable(TABLE_NAME, (table) => {
+    table.dropColumn("isActive");
+  });
+};
+
+export { down, up };

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -12,6 +12,7 @@
         "eslint-plugin-simple-import-sort": "^12.1.1",
         "eslint-plugin-vitest-globals": "^1.5.0",
         "express": "^5.1.0",
+        "jsonwebtoken": "^9.0.2",
         "knex": "^3.1.0",
         "lodash": "^4.17.21",
         "pg": "^8.16.3",
@@ -1539,6 +1540,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -1938,6 +1945,15 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -3129,6 +3145,49 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -3256,11 +3315,47 @@
       "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
       "license": "MIT"
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
       "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -3274,6 +3369,12 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
       "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/loupe": {
@@ -4289,7 +4390,6 @@
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/api/package.json
+++ b/api/package.json
@@ -37,6 +37,7 @@
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "eslint-plugin-vitest-globals": "^1.5.0",
     "express": "^5.1.0",
+    "jsonwebtoken": "^9.0.2",
     "knex": "^3.1.0",
     "lodash": "^4.17.21",
     "pg": "^8.16.3",

--- a/api/src/identities-access-management/services/token-service.js
+++ b/api/src/identities-access-management/services/token-service.js
@@ -1,0 +1,40 @@
+import jwt from "jsonwebtoken";
+
+import { config } from "../../../config.js";
+
+class TokenService {
+  constructor() {
+    this.secret = config.jwt.tokenSecret;
+    this.expirationTime = config.jwt.expirationTime || "1h";
+  }
+
+  async encodedToken(data) {
+    if (!this.secret) {
+      throw new Error("JWT secret is not configured");
+    }
+
+    return jwt.sign(data, this.secret, {
+      expiresIn: this.expirationTime,
+    });
+  }
+
+  decodedToken(token) {
+    if (!this.secret) {
+      throw new Error("JWT secret is not configured");
+    }
+
+    try {
+      return jwt.verify(token, this.secret);
+    } catch (error) {
+      if (error.name === "TokenExpiredError") {
+        throw new Error("Token has expired");
+      } else if (error.name === "JsonWebTokenError") {
+        throw new Error("Invalid token");
+      } else {
+        throw new Error("Token verification failed");
+      }
+    }
+  }
+}
+
+export default new TokenService();

--- a/api/tests/identities-access-management/services/token-service.test.js
+++ b/api/tests/identities-access-management/services/token-service.test.js
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import tokenService from "../../../src/identities-access-management/services/token-service.js";
+
+vi.mock("../../../config.js", () => ({
+  config: {
+    jwt: {
+      tokenSecret: "test-secret-key",
+      expirationTime: "1h",
+    },
+  },
+}));
+
+describe("TokenService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("encodedToken", () => {
+    it("should encode data into a JWT token", async () => {
+      const testData = { userId: 123, email: "test@example.com" };
+
+      const token = await tokenService.encodedToken(testData);
+
+      expect(token).toBeDefined();
+      expect(typeof token).toBe("string");
+      expect(token.split(".")).toHaveLength(3);
+    });
+
+    it("should encode different data types", async () => {
+      const testData = {
+        string: "test",
+        number: 42,
+        boolean: true,
+        object: { nested: "value" },
+      };
+
+      const token = await tokenService.encodedToken(testData);
+
+      expect(token).toBeDefined();
+      expect(typeof token).toBe("string");
+    });
+
+    it("should throw error when secret is not configured", async () => {
+      const originalSecret = tokenService.secret;
+      tokenService.secret = null;
+
+      await expect(tokenService.encodedToken({ test: "data" }))
+        .rejects.toThrow("JWT secret is not configured");
+
+      tokenService.secret = originalSecret;
+    });
+  });
+
+  describe("decodedToken", () => {
+    it("should decode a valid JWT token", async () => {
+      const testData = { userId: 123, email: "test@example.com" };
+      const token = await tokenService.encodedToken(testData);
+
+      const decoded = tokenService.decodedToken(token);
+
+      expect(decoded).toMatchObject(testData);
+      expect(decoded.iat).toBeDefined();
+      expect(decoded.exp).toBeDefined();
+    });
+
+    it("should throw error for invalid token", () => {
+      const invalidToken = "invalid.token.here";
+
+      expect(() => tokenService.decodedToken(invalidToken))
+        .toThrow("Invalid token");
+    });
+
+    it("should throw error for expired token", async () => {
+      const originalExpirationTime = tokenService.expirationTime;
+      tokenService.expirationTime = "1ms";
+
+      const testData = { userId: 123 };
+      const token = await tokenService.encodedToken(testData);
+
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(() => tokenService.decodedToken(token))
+        .toThrow("Token has expired");
+
+      tokenService.expirationTime = originalExpirationTime;
+    });
+
+    it("should throw error when secret is not configured", () => {
+      const originalSecret = tokenService.secret;
+      tokenService.secret = null;
+
+      expect(() => tokenService.decodedToken("any.token.here"))
+        .toThrow("JWT secret is not configured");
+
+      tokenService.secret = originalSecret;
+    });
+  });
+
+  describe("integration", () => {
+    it("should encode and decode data correctly", async () => {
+      const originalData = {
+        userId: 456,
+        email: "integration@test.com",
+        role: "admin",
+        permissions: ["read", "write"],
+      };
+
+      const token = await tokenService.encodedToken(originalData);
+      const decodedData = tokenService.decodedToken(token);
+
+      expect(decodedData.userId).toBe(originalData.userId);
+      expect(decodedData.email).toBe(originalData.email);
+      expect(decodedData.role).toBe(originalData.role);
+      expect(decodedData.permissions).toEqual(originalData.permissions);
+    });
+  });
+});


### PR DESCRIPTION
tech(api): create JWT token service

- Add TokenService class with encodedToken and decodedToken methods
- Use config.jwt.tokenSecret and config.jwt.expirationTime from config.js
- Add comprehensive test suite with 8 test cases
- Support for async encodedToken as required by issue #41
- Proper error handling for invalid/expired tokens and missing secrets

