### PR TITLE
tech(api): create a service to send the mail activation

### DIFF
--- a/api/email-templates/account-activation.md
+++ b/api/email-templates/account-activation.md
@@ -1,6 +1,6 @@
 # Activation de votre compte Kompagnon
 
-Bonjour {{firstName}} {{lastname}},
+Bonjour {{firstname}} {{lastname}},
 
 Bienvenue sur Kompagnon ! Nous sommes ravis de vous compter parmi nous.
 

--- a/api/src/identities-access-management/services/send-mail-to-activate-account-service.js
+++ b/api/src/identities-access-management/services/send-mail-to-activate-account-service.js
@@ -1,0 +1,25 @@
+import { config } from "../../../config.js";
+import { createMailBodyService } from "../../shared/services/emails/create-mail-body-service.js";
+import { sendMailService } from "../../shared/services/emails/send-mail-service.js";
+
+const ACTIVATE_PATH = "authentication/activate?token=";
+const MAIL_SUBJECT = "Activer votre compte Kompagnon";
+
+async function sendMailToActivateUserService({ firstname, lastname, email, token, createMailBody = createMailBodyService, sendMail = sendMailService }) {
+  const body = await createMailBody("account-activation", {
+    firstname,
+    lastname,
+    activationLink: _getUrlToActivateAccount(token),
+  });
+  await sendMail({
+    to: email,
+    subject: MAIL_SUBJECT,
+    html: body,
+  });
+}
+
+function _getUrlToActivateAccount(token) {
+  return `${config.baseUrl}${ACTIVATE_PATH}${token}`;
+}
+
+export { sendMailToActivateUserService };

--- a/api/tests/identities-access-management/integration/services/send-mail-to-activate-account-service.test.js
+++ b/api/tests/identities-access-management/integration/services/send-mail-to-activate-account-service.test.js
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { sendMailToActivateUserService } from "../../../../src/identities-access-management/services/send-mail-to-activate-account-service.js";
+
+describe("Integration | Identities Access Management | Service | Send mail to activate account", () => {
+  it("should generate and send activation mail with correct content", async () => {
+    // given
+    const firstname = "Alice";
+    const lastname = "Martin";
+    const email = "alice.martin@example.com";
+    const token = "integration-token-123";
+    let mailSent = null;
+
+    function sendMail({ to, subject, html }) {
+      mailSent = { to, subject, html };
+      return Promise.resolve();
+    }
+
+    // when
+    await sendMailToActivateUserService({
+      firstname,
+      lastname,
+      email,
+      token,
+      sendMail,
+    });
+    // then
+    expect(mailSent).not.toBeNull();
+    expect(mailSent.to).toBe(email);
+    expect(mailSent.subject).toContain("Activer votre compte Kompagnon");
+    expect(mailSent.html).toContain(firstname);
+    expect(mailSent.html).toContain(lastname);
+    expect(mailSent.html).toContain(token);
+    expect(mailSent.html).toContain("authentication/activate?token=" + token);
+  });
+});
+

--- a/api/tests/identities-access-management/unit/services/send-mail-to-activate-account-service.test.js
+++ b/api/tests/identities-access-management/unit/services/send-mail-to-activate-account-service.test.js
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { sendMailToActivateUserService } from "../../../../src/identities-access-management/services/send-mail-to-activate-account-service.js";
+
+describe("Unit | Identities Access Management | Service | Send mail to activate account", () => {
+  it("should generate mail body and call sendMail with correct params", async () => {
+    // given
+    const mockCreateMailBody = vi.fn().mockResolvedValue("<html lang=\"fr\">body</html>");
+    const mockSendMail = vi.fn().mockResolvedValue();
+    const input = {
+      firstname: "Jean",
+      lastname: "Dupont",
+      email: "jean.dupont@example.com",
+      token: "abc123",
+      createMailBody: mockCreateMailBody,
+      sendMail: mockSendMail,
+    };
+
+    // when
+    await sendMailToActivateUserService(input);
+
+    // then
+    expect(mockCreateMailBody).toHaveBeenCalledWith("account-activation", {
+      firstname: "Jean",
+      lastname: "Dupont",
+      activationLink: expect.stringContaining("abc123"),
+    });
+    expect(mockSendMail).toHaveBeenCalledWith({
+      to: "jean.dupont@example.com",
+      subject: expect.stringContaining("Activer votre compte Kompagnon"),
+      html: "<html lang=\"fr\">body</html>",
+    });
+  });
+
+  it("should throw if createMailBody throws an error", async () => {
+    // given
+    const mockCreateMailBody = vi.fn().mockRejectedValue(new Error("Mail body error"));
+    const mockSendMail = vi.fn();
+    const input = {
+      firstname: "Jean",
+      lastname: "Dupont",
+      email: "jean.dupont@example.com",
+      token: "abc123",
+      createMailBody: mockCreateMailBody,
+      sendMail: mockSendMail,
+    };
+    // when & then
+    await expect(sendMailToActivateUserService(input)).rejects.toThrow("Mail body error");
+  });
+
+  it("should throw if sendMail throws an error", async () => {
+    // given
+    const mockCreateMailBody = vi.fn().mockResolvedValue("<html lang=\"fr\">body</html>");
+    const mockSendMail = vi.fn().mockRejectedValue(new Error("Send mail error"));
+    const input = {
+      firstname: "Jean",
+      lastname: "Dupont",
+      email: "jean.dupont@example.com",
+      token: "abc123",
+      createMailBody: mockCreateMailBody,
+      sendMail: mockSendMail,
+    };
+    // when & then
+    await expect(sendMailToActivateUserService(input)).rejects.toThrow("Send mail error");
+  });
+});


### PR DESCRIPTION
This pull request introduces a new service for sending account activation emails and adds corresponding integration and unit tests to ensure its correct behavior. It also fixes a variable naming inconsistency in the email template.

**Account Activation Email Service:**

* Added `sendMailToActivateUserService` in `send-mail-to-activate-account-service.js`, which generates and sends activation emails using configurable mail body and sending services. It constructs the activation link using the user's token and the configured base URL.

**Testing:**

* Added integration test `send-mail-to-activate-account-service.test.js` to verify that the activation email is generated and sent with the correct content, including the activation link and user details.
* Added unit test `send-mail-to-activate-account-service.test.js` to check that the mail body and send functions are called with the correct parameters, and that errors are correctly propagated when mail body or sending fails.

**Template Fix:**

* Fixed variable naming in `account-activation.md` to use `firstname` instead of `firstName` for consistency with the service and tests.