### PR TITLE
tech: use actions from edp5

### DIFF
--- a/.github/workflows/PR Title Check.yml
+++ b/.github/workflows/PR Title Check.yml
@@ -12,17 +12,4 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check out the repository
-        uses: actions/checkout@v5
-
-      - name: Validate PR title
-        run: |
-          # exit with 0 if is merge queue
-            if [[ "${{ github.event_name }}" == "merge_group" ]]; then
-                echo "Merge group event detected. Skipping PR title check."
-                exit 0
-            fi
-          if [[ ! "$(echo '${{ github.event.pull_request.title }}' | grep -E '^(fix|feat|tech|docs|bump|style|refactor|chore|perf|test|revert|breaking)(\([^)]+\))?:')" ]]; then
-            echo "Error: Pull request title must start with one of the following keywords: fix, feat, tech, docs, bump, style, refactor, chore, perf, test, breaking or revert. Optionally, it can include a scope in parentheses followed by a colon (e.g., 'feat(scope):')."
-            exit 1
-          fi
+      - uses: edp5/edp5-actions/pr-title-check@v1.0.1


### PR DESCRIPTION
## Problem

The pull request validation workflow was rewritten in several projects. It was rewritten in edp5-actions.

## Solution

Use this workflow.

### Note

We have simplified the call of the auto merge workflow in the auto merge.