### PR TITLE
tech: use the github action token on auto merge

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -19,4 +19,4 @@ jobs:
       - name: Call auto merge
         uses: edp5/edp5-actions/auto-merge@main
         with:
-            token: ${{ secrets.SERVICE_TOKEN }}
+            token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request makes a small update to the `auto-merge.yml` workflow configuration by switching the authentication token used for the auto-merge action from `SERVICE_TOKEN` to `GITHUB_TOKEN`. This improves security and simplifies secret management.