### PR TITLE
tech: add option to run checks on merge queue

### DIFF
--- a/.github/workflows/PR Title Check.yml
+++ b/.github/workflows/PR Title Check.yml
@@ -5,6 +5,7 @@ on:
     types: [opened, reopened, edited, synchronize]
     branches:
       - main
+  merge_group:
 
 jobs:
   check-title:
@@ -16,6 +17,11 @@ jobs:
 
       - name: Validate PR title
         run: |
+          # exit with 0 if is merge queue
+            if [[ "${{ github.event_name }}" == "merge_group" ]]; then
+                echo "Merge group event detected. Skipping PR title check."
+                exit 0
+            fi
           if [[ ! "$(echo '${{ github.event.pull_request.title }}' | grep -E '^(fix|feat|tech|docs|bump|style|refactor|chore|perf|test|revert|breaking)(\([^)]+\))?:')" ]]; then
             echo "Error: Pull request title must start with one of the following keywords: fix, feat, tech, docs, bump, style, refactor, chore, perf, test, breaking or revert. Optionally, it can include a scope in parentheses followed by a colon (e.g., 'feat(scope):')."
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ on:
   push:
     branches:
       - main
+  merge_group:
 
 jobs:
   api-lint:

--- a/.github/workflows/commits-check.yaml
+++ b/.github/workflows/commits-check.yaml
@@ -2,10 +2,13 @@ name: commits check
 
 on:
   pull_request:
+  merge_group:
 
 jobs:
   block-autosquash-commits:
     runs-on: ubuntu-latest
+    # Run only if not merge queue
+    if: github.event_name != 'merge_group'
     permissions:
       pull-requests: read
     steps:


### PR DESCRIPTION
This pull request updates several GitHub Actions workflow files to enable triggering on `merge_group` events. This change ensures that the workflows will run for merge group events, which are used in GitHub's merge queue and can help improve CI reliability and automation for pull requests.

Workflow trigger updates:

* [`.github/workflows/PR Title Check.yml`](diffhunk://#diff-e6d2be8389bd688a7879afcde237f873c599b6d1fe794a6a4352e4a428192e93R8): Added `merge_group` to the workflow triggers to ensure PR title checks run for merge group events.
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR15): Included `merge_group` in the workflow triggers so CI checks are performed for merge group events.
* [`.github/workflows/commits-check.yaml`](diffhunk://#diff-f638afde9f4abd99413459359a4a2d2e915346e83c42d4064655e739d0aacdbaR5): Added `merge_group` to the workflow triggers to block autosquash commits for merge group events.