### PR TITLE
tech(web&admin): Create a Password component

### DIFF
--- a/admin/src/components/PasswordComponent.vue
+++ b/admin/src/components/PasswordComponent.vue
@@ -1,0 +1,96 @@
+<script setup>
+import { computed, ref } from "vue";
+
+defineProps({
+  label: {
+    type: String,
+    default: "mot de passe",
+  },
+  modelValue: {
+    type: String,
+    default: "",
+  },
+});
+
+const emit = defineEmits(["update:modelValue"]);
+
+const showPassword = ref(false);
+const inputType = computed(() => (showPassword.value ? "text" : "password"));
+
+function togglePasswordVisibility() {
+  showPassword.value = !showPassword.value;
+}
+
+function updateValue(event) {
+  emit("update:modelValue", event.target.value);
+}
+</script>
+
+<template>
+  <div class="password-component">
+    <label :for="`password-${label}`">{{ label }}</label>
+    <div class="password-input-wrapper">
+      <input
+        :id="`password-${label}`"
+        :type="inputType"
+        :value="modelValue"
+        @input="updateValue"
+        class="password-input"
+      />
+      <button
+        type="button"
+        @click="togglePasswordVisibility"
+        class="toggle-button"
+        :aria-label="showPassword ? 'Masquer le mot de passe' : 'Afficher le mot de passe'"
+      >
+        {{ showPassword ? "👁️" : "👁️‍🗨️" }}
+      </button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.password-component {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5em;
+}
+
+.password-input-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.password-input {
+  width: 100%;
+  padding: 0.5em;
+  padding-right: 2.5em;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 1em;
+}
+
+.toggle-button {
+  position: absolute;
+  right: 0.5em;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.25em;
+  font-size: 1.2em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.toggle-button:hover {
+  opacity: 0.7;
+}
+
+label {
+  font-weight: 500;
+  color: #333;
+}
+</style>
+

--- a/admin/tests/integration/components/PasswordComponent.spec.js
+++ b/admin/tests/integration/components/PasswordComponent.spec.js
@@ -1,0 +1,124 @@
+import { mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import PasswordComponent from "@/components/PasswordComponent.vue";
+
+describe("Integration | Components | PasswordComponent", () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = mount(PasswordComponent);
+  });
+
+  it("should display default label", () => {
+    // then
+    const label = wrapper.find("label");
+    expect(label.text()).toBe("mot de passe");
+  });
+
+  it("should display custom label", () => {
+    // given & when
+    wrapper = mount(PasswordComponent, {
+      props: {
+        label: "New Password",
+      },
+    });
+
+    // then
+    const label = wrapper.find("label");
+    expect(label.text()).toBe("New Password");
+  });
+
+  it("should have password input type by default", () => {
+    // then
+    const input = wrapper.find("input");
+    expect(input.attributes("type")).toBe("password");
+  });
+
+  it("should toggle password visibility when button is clicked", async () => {
+    // given
+    const input = wrapper.find("input");
+    const button = wrapper.find("button");
+
+    // when
+    await button.trigger("click");
+
+    // then
+    expect(input.attributes("type")).toBe("text");
+  });
+
+  it("should toggle back to password type when button is clicked twice", async () => {
+    // given
+    const input = wrapper.find("input");
+    const button = wrapper.find("button");
+
+    // when
+    await button.trigger("click");
+
+    // then
+    expect(input.attributes("type")).toBe("text");
+    wrapper.vm.showPassword = true;
+
+    // when
+    await button.trigger("click");
+
+    // then
+    expect(input.attributes("type")).toBe("password");
+  });
+
+  it("should update aria-label when password is visible", async () => {
+    // given
+    const button = wrapper.find("button");
+
+    // when
+    await button.trigger("click");
+
+    // then
+    expect(button.attributes("aria-label")).toBe("Masquer le mot de passe");
+  });
+
+  it("should update aria-label when password is hidden", () => {
+    // then
+    const button = wrapper.find("button");
+    expect(button.attributes("aria-label")).toBe("Afficher le mot de passe");
+  });
+
+  it("should emit update:modelValue when input value changes", async () => {
+    // given
+    const input = wrapper.find("input");
+
+    // when
+    await input.setValue("test123");
+
+    // then
+    expect(wrapper.emitted("update:modelValue")).toBeTruthy();
+    expect(wrapper.emitted("update:modelValue")[0]).toEqual(["test123"]);
+  });
+
+  it("should bind modelValue to input value", () => {
+    // given
+    wrapper = mount(PasswordComponent, {
+      props: {
+        modelValue: "initialValue",
+      },
+    });
+
+    // then
+    const input = wrapper.find("input");
+    expect(input.element.value).toBe("initialValue");
+  });
+
+  it("should have correct input id based on label", () => {
+    // given
+    wrapper = mount(PasswordComponent, {
+      props: {
+        label: "custom-password",
+      },
+    });
+
+    // then
+    const input = wrapper.find("input");
+    expect(input.attributes("id")).toBe("password-custom-password");
+  });
+});
+

--- a/web/src/components/PasswordComponent.vue
+++ b/web/src/components/PasswordComponent.vue
@@ -1,0 +1,96 @@
+<script setup>
+import { computed, ref } from "vue";
+
+defineProps({
+  label: {
+    type: String,
+    default: "mot de passe",
+  },
+  modelValue: {
+    type: String,
+    default: "",
+  },
+});
+
+const emit = defineEmits(["update:modelValue"]);
+
+const showPassword = ref(false);
+const inputType = computed(() => (showPassword.value ? "text" : "password"));
+
+function togglePasswordVisibility() {
+  showPassword.value = !showPassword.value;
+}
+
+function updateValue(event) {
+  emit("update:modelValue", event.target.value);
+}
+</script>
+
+<template>
+  <div class="password-component">
+    <label :for="`password-${label}`">{{ label }}</label>
+    <div class="password-input-wrapper">
+      <input
+        :id="`password-${label}`"
+        :type="inputType"
+        :value="modelValue"
+        @input="updateValue"
+        class="password-input"
+      />
+      <button
+        type="button"
+        @click="togglePasswordVisibility"
+        class="toggle-button"
+        :aria-label="showPassword ? 'Masquer le mot de passe' : 'Afficher le mot de passe'"
+      >
+        {{ showPassword ? "👁️" : "👁️‍🗨️" }}
+      </button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.password-component {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5em;
+}
+
+.password-input-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.password-input {
+  width: 100%;
+  padding: 0.5em;
+  padding-right: 2.5em;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 1em;
+}
+
+.toggle-button {
+  position: absolute;
+  right: 0.5em;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.25em;
+  font-size: 1.2em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.toggle-button:hover {
+  opacity: 0.7;
+}
+
+label {
+  font-weight: 500;
+  color: #333;
+}
+</style>
+

--- a/web/tests/integration/components/PasswordComponent.spec.js
+++ b/web/tests/integration/components/PasswordComponent.spec.js
@@ -1,0 +1,124 @@
+import { mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import PasswordComponent from "@/components/PasswordComponent.vue";
+
+describe("Integration | Components | PasswordComponent", () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = mount(PasswordComponent);
+  });
+
+  it("should display default label", () => {
+    // then
+    const label = wrapper.find("label");
+    expect(label.text()).toBe("mot de passe");
+  });
+
+  it("should display custom label", () => {
+    // given & when
+    wrapper = mount(PasswordComponent, {
+      props: {
+        label: "New Password",
+      },
+    });
+
+    // then
+    const label = wrapper.find("label");
+    expect(label.text()).toBe("New Password");
+  });
+
+  it("should have password input type by default", () => {
+    // then
+    const input = wrapper.find("input");
+    expect(input.attributes("type")).toBe("password");
+  });
+
+  it("should toggle password visibility when button is clicked", async () => {
+    // given
+    const input = wrapper.find("input");
+    const button = wrapper.find("button");
+
+    // when
+    await button.trigger("click");
+
+    // then
+    expect(input.attributes("type")).toBe("text");
+  });
+
+  it("should toggle back to password type when button is clicked twice", async () => {
+    // given
+    const input = wrapper.find("input");
+    const button = wrapper.find("button");
+
+    // when
+    await button.trigger("click");
+
+    // then
+    expect(input.attributes("type")).toBe("text");
+    wrapper.vm.showPassword = true;
+
+    // when
+    await button.trigger("click");
+
+    // then
+    expect(input.attributes("type")).toBe("password");
+  });
+
+  it("should update aria-label when password is visible", async () => {
+    // given
+    const button = wrapper.find("button");
+
+    // when
+    await button.trigger("click");
+
+    // then
+    expect(button.attributes("aria-label")).toBe("Masquer le mot de passe");
+  });
+
+  it("should update aria-label when password is hidden", () => {
+    // then
+    const button = wrapper.find("button");
+    expect(button.attributes("aria-label")).toBe("Afficher le mot de passe");
+  });
+
+  it("should emit update:modelValue when input value changes", async () => {
+    // given
+    const input = wrapper.find("input");
+
+    // when
+    await input.setValue("test123");
+
+    // then
+    expect(wrapper.emitted("update:modelValue")).toBeTruthy();
+    expect(wrapper.emitted("update:modelValue")[0]).toEqual(["test123"]);
+  });
+
+  it("should bind modelValue to input value", () => {
+    // given
+    wrapper = mount(PasswordComponent, {
+      props: {
+        modelValue: "initialValue",
+      },
+    });
+
+    // then
+    const input = wrapper.find("input");
+    expect(input.element.value).toBe("initialValue");
+  });
+
+  it("should have correct input id based on label", () => {
+    // given
+    wrapper = mount(PasswordComponent, {
+      props: {
+        label: "custom-password",
+      },
+    });
+
+    // then
+    const input = wrapper.find("input");
+    expect(input.attributes("id")).toBe("password-custom-password");
+  });
+});
+


### PR DESCRIPTION
## Description

This PR creates a PasswordComponent.vue in both web and admin directories.

## Changes

- Add PasswordComponent with toggle visibility functionality
- Component accepts label prop (default: 'password')
- Input switches between password and text type
- Created in both web and admin directories

## Related Issue

Closes #81