### PR TITLE
tech: Include docker packages in dependabot check

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,3 +31,31 @@ updates:
     commit-message:
       prefix: bump
       include: scope
+
+  # Fetch and update latest 'docker' packages
+  - package-ecosystem: docker
+    directory: '/'
+    schedule:
+      interval: daily
+      time: '00:00'
+    open-pull-requests-limit: 2
+    labels:
+      - Ready to merge
+
+    commit-message:
+      prefix: bump
+      include: scope
+
+  # Fetch and update latest 'docker-compose' packages
+  - package-ecosystem: docker-compose
+    directory: '/'
+    schedule:
+      interval: daily
+      time: '00:00'
+    open-pull-requests-limit: 2
+    labels:
+      - Ready to merge
+
+    commit-message:
+      prefix: bump
+      include: scope


### PR DESCRIPTION
This pull request adds configuration to enable Dependabot to check for updates to Docker packages in the repository. This ensures that Docker dependencies are kept up to date automatically.

Dependency management improvements:

* Added a new `docker` package-ecosystem entry in `.github/dependabot.yml` to enable daily checks for Docker package updates, with a maximum of two open pull requests at a time and a custom commit message prefix.