### PR TITLE
fix: Remove the userType of registration route

### DIFF
--- a/api/src/identities-access-management/controllers/register-user-controller.js
+++ b/api/src/identities-access-management/controllers/register-user-controller.js
@@ -1,7 +1,6 @@
 import { celebrate, Joi } from "celebrate";
 
 import { logger } from "../../../logger.js";
-import { USER_TYPES } from "../../shared/constants.js";
 import ERRORS from "../errors.js";
 import { createNewUser } from "../repositories/user-repository.js";
 import { generatePassword } from "../services/password-service.js";
@@ -15,7 +14,6 @@ const registerUserSchema = celebrate({
     lastname: Joi.string().required(),
     password: Joi.string().required(),
     birthday: Joi.string().required(),
-    userType: Joi.string().required().valid(...Object.values(USER_TYPES)),
   }),
 });
 
@@ -40,9 +38,9 @@ async function registerUserController(
   encodedTokenService = encodedToken,
 ) {
   try {
-    const { firstname, lastname, email, password, birthday, userType } = req.body;
+    const { firstname, lastname, email, password, birthday } = req.body;
     const hashedPassword = await generatePasswordService(password);
-    const userId = await createUserRepository({ firstname, lastname, email, birthday, hashedPassword, userType });
+    const userId = await createUserRepository({ firstname, lastname, email, birthday, hashedPassword });
     await sendMailActivationService({ firstname, lastname, token: encodedTokenService({ userId }), email });
     return res.status(201).send();
   } catch (error) {

--- a/api/tests/identities-access-management/acceptance/authentication-routes.test.js
+++ b/api/tests/identities-access-management/acceptance/authentication-routes.test.js
@@ -5,7 +5,6 @@ import databaseBuilder from "../../../db/database-builder/index.js";
 import { knex } from "../../../db/knex-database-connection.js";
 import server from "../../../server.js";
 import { encodedToken } from "../../../src/identities-access-management/services/token-service.js";
-import { DEFAULT_USER_TYPE } from "../../../src/shared/constants.js";
 
 describe("Acceptance | Identities Access Management | Routes | Authentication routes", () => {
   describe("POST /api/authentication/register", () => {
@@ -16,7 +15,6 @@ describe("Acceptance | Identities Access Management | Routes | Authentication ro
         lastname: "Doe",
         email: "john.doe@example.net",
         password: "password",
-        userType: DEFAULT_USER_TYPE,
         birthday: "01/01/2001",
       };
 
@@ -47,8 +45,6 @@ describe("Acceptance | Identities Access Management | Routes | Authentication ro
         lastname: "Doe",
         email: "john.doe@example.net",
         password: "password",
-        userType: "useeeeer",
-        birthday: "01/01/2001",
       };
 
       // when

--- a/api/tests/identities-access-management/unit/controllers/register-user-controller.test.js
+++ b/api/tests/identities-access-management/unit/controllers/register-user-controller.test.js
@@ -29,7 +29,6 @@ describe("Unit | Identities Access Management | Controller | Register new user",
         lastname: "Doe",
         email: "john.doe@example.net",
         password: "Password",
-        userType: "admin",
       },
     };
     createUserRepository.mockResolvedValue(123);
@@ -46,7 +45,6 @@ describe("Unit | Identities Access Management | Controller | Register new user",
       lastname: req.body.lastname,
       email: req.body.email,
       hashedPassword: "hashedPassword",
-      userType: req.body.userType,
     });
     expect(sendMailActivationService).toHaveBeenCalledWith({ firstname: req.body.firstname, lastname: req.body.lastname, token: "token", email: req.body.email });
     expect(res.status).toHaveBeenCalledWith(201);
@@ -62,7 +60,6 @@ describe("Unit | Identities Access Management | Controller | Register new user",
           lastname: "Doe",
           email: "john.doe@example.net",
           password: "Password",
-          userType: "admin",
         },
       };
       const error = new Error("Database connection failed");


### PR DESCRIPTION
This pull request removes the `userType` field from the user registration process in both the backend controller and associated tests. The registration endpoint no longer requires or processes a `userType` value, simplifying the user creation flow and its validation.

**Backend changes:**

* Removed `userType` from the registration validation schema and controller logic in `register-user-controller.js`, so new users are registered without specifying a user type. [[1]](diffhunk://#diff-d1f8d808459679e549d34a01ec1fca1481daceca693de3e6e0b33134a8755611L4) [[2]](diffhunk://#diff-d1f8d808459679e549d34a01ec1fca1481daceca693de3e6e0b33134a8755611L18) [[3]](diffhunk://#diff-d1f8d808459679e549d34a01ec1fca1481daceca693de3e6e0b33134a8755611L43-R43)

**Test updates:**

* Updated acceptance tests in `authentication-routes.test.js` to remove the `userType` field from test payloads, ensuring tests align with the new registration requirements. [[1]](diffhunk://#diff-282b00888bec4c359e18c111a402b1659908f5b3662c98d7eac806ed0653a428L8) [[2]](diffhunk://#diff-282b00888bec4c359e18c111a402b1659908f5b3662c98d7eac806ed0653a428L19) [[3]](diffhunk://#diff-282b00888bec4c359e18c111a402b1659908f5b3662c98d7eac806ed0653a428L50-L51)
* Updated unit tests in `register-user-controller.test.js` to remove expectations and mock data related to `userType`. [[1]](diffhunk://#diff-270682ce6f33372436d0538f36c5d6dd02337bb906dbd6b15a6653c5b8761d65L32) [[2]](diffhunk://#diff-270682ce6f33372436d0538f36c5d6dd02337bb906dbd6b15a6653c5b8761d65L49) [[3]](diffhunk://#diff-270682ce6f33372436d0538f36c5d6dd02337bb906dbd6b15a6653c5b8761d65L65)