### PR TITLE
feat: create an activation page

### DIFF
--- a/web/src/adapters/authentication.js
+++ b/web/src/adapters/authentication.js
@@ -68,5 +68,37 @@ async function loginUser({ email, password }) {
   }
 }
 
-export { loginUser, registerNewUser };
+async function activateAccount({ token }) {
+  try {
+    const response = await fetch(`${AUTHENTICATION_URL}activate?token=${encodeURIComponent(token)}`, {
+      method: "GET",
+    });
 
+    switch (response.status) {
+    case 201:
+      return { success: true, message: "Compte activé avec succès !" };
+    case 400:
+      return {
+        success: false,
+        message: "Token invalide ou expiré.",
+      };
+    case 401:
+      return {
+        success: false,
+        message: "Utilisateur non trouvé ou déjà actif.",
+      };
+    default:
+      return {
+        success: false,
+        message: "Échec de l'activation. Veuillez réessayer.",
+      };
+    }
+  } catch {
+    return {
+      success: false,
+      message: "Impossible de joindre le serveur. Veuillez réessayer plus tard.",
+    };
+  }
+}
+
+export { loginUser, registerNewUser, activateAccount };

--- a/web/src/adapters/authentication.js
+++ b/web/src/adapters/authentication.js
@@ -101,4 +101,4 @@ async function activateAccount({ token }) {
   }
 }
 
-export { loginUser, registerNewUser, activateAccount };
+export { activateAccount, loginUser, registerNewUser };

--- a/web/src/router/index.js
+++ b/web/src/router/index.js
@@ -21,6 +21,11 @@ const router = createRouter({
       name: "register",
       component: RegisterView,
     },
+    {
+      path: "/authentication/activate",
+      name: "activate-account",
+      component: ActivateAccountView,
+    },
   ],
 });
 

--- a/web/src/router/index.js
+++ b/web/src/router/index.js
@@ -1,5 +1,6 @@
 import { createRouter, createWebHistory } from "vue-router";
 
+import ActivateAccountView from "@/views/authentication/ActivateAccountView.vue";
 import LoginView from "@/views/authentication/LoginView.vue";
 import RegisterView from "@/views/authentication/RegisterView.vue";
 

--- a/web/src/views/authentication/ActivateAccountView.vue
+++ b/web/src/views/authentication/ActivateAccountView.vue
@@ -1,0 +1,65 @@
+<script setup>
+import { onMounted, ref } from "vue";
+import { useRoute } from "vue-router";
+
+import { activateAccount } from "@/adapters/authentication.js";
+
+const route = useRoute();
+const loading = ref(true);
+const message = ref("");
+const success = ref(false);
+
+onMounted(async () => {
+  const token = route.query.token;
+
+  if (!token) {
+    message.value = "Token d'activation manquant.";
+    success.value = false;
+    loading.value = false;
+    return;
+  }
+
+  const result = await activateAccount({ token });
+  message.value = result.message;
+  success.value = result.success;
+  loading.value = false;
+});
+</script>
+
+<template>
+  <div class="activation-container">
+    <h1>Activation de compte</h1>
+
+    <div
+      v-if="loading"
+      class="loading"
+    >
+      <p>Activation en cours...</p>
+    </div>
+
+    <div
+      v-else
+      class="result"
+    >
+      <p :class="{ 'success-message': success, 'error-message': !success }">
+        {{ message }}
+      </p>
+
+      <router-link
+        v-if="success"
+        to="/login"
+        class="action-link"
+      >
+        Aller à la connexion
+      </router-link>
+
+      <router-link
+        v-else
+        to="/register"
+        class="action-link"
+      >
+        Retour à l'inscription
+      </router-link>
+    </div>
+  </div>
+</template>

--- a/web/tests/unit/views/authentication/ActivateAccountView.spec.js
+++ b/web/tests/unit/views/authentication/ActivateAccountView.spec.js
@@ -1,0 +1,117 @@
+import { flushPromises, mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { activateAccount } from "@/adapters/authentication.js";
+import ActivateAccountView from "@/views/authentication/ActivateAccountView.vue";
+
+vi.mock("@/adapters/authentication.js", () => ({
+  activateAccount: vi.fn(),
+}));
+
+const mockRoute = {
+  query: {},
+};
+
+vi.mock("vue-router", () => ({
+  useRoute: () => mockRoute,
+  RouterLink: {
+    template: "<a><slot /></a>",
+  },
+}));
+
+describe("Unit | Views | Authentication | AuthenticationView", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRoute.query = {};
+  });
+
+  describe("when token is missing", () => {
+    it("should display an error message when no token is provided", async () => {
+      // given
+      mockRoute.query = {};
+
+      // when
+      const wrapper = mount(ActivateAccountView);
+      await flushPromises();
+
+      // then
+      expect(activateAccount).not.toHaveBeenCalled();
+      expect(wrapper.text()).toContain("Token d'activation manquant.");
+    });
+
+    it("should show link to registration page when token is missing", async () => {
+      // given
+      mockRoute.query = {};
+
+      // when
+      const wrapper = mount(ActivateAccountView);
+      await flushPromises();
+
+      // then
+      expect(wrapper.text()).toContain("Retour à l'inscription");
+    });
+  });
+
+  describe("when token is provided", () => {
+    it("should call activateAccount with the token from query params", async () => {
+      // given
+      const token = "valid-test-token";
+      mockRoute.query = { token };
+      activateAccount.mockResolvedValue({ success: true, message: "Compte activé avec succès !" });
+
+      // when
+      const wrapper = mount(ActivateAccountView);
+      await flushPromises();
+
+      // then
+      expect(activateAccount).toHaveBeenCalledWith({ token });
+      expect(wrapper.text()).toContain("Compte activé avec succès !");
+    });
+
+    it("should display loading state while activation is in progress", async () => {
+      // given
+      mockRoute.query = { token: "test-token" };
+      let resolveActivation;
+      activateAccount.mockReturnValue(new Promise((resolve) => {
+        resolveActivation = resolve;
+      }));
+
+      // when
+      const wrapper = mount(ActivateAccountView);
+
+      // then
+      expect(wrapper.text()).toContain("Activation en cours...");
+
+      // cleanup
+      resolveActivation({ success: true, message: "Done" });
+      await flushPromises();
+    });
+
+    it("should show link to login page on successful activation", async () => {
+      // given
+      mockRoute.query = { token: "valid-token" };
+      activateAccount.mockResolvedValue({ success: true, message: "Compte activé avec succès !" });
+
+      // when
+      const wrapper = mount(ActivateAccountView);
+      await flushPromises();
+
+      // then
+      expect(wrapper.text()).toContain("Aller à la connexion");
+    });
+
+    it("should show error message and registration link on activation failure", async () => {
+      // given
+      mockRoute.query = { token: "invalid-token" };
+      activateAccount.mockResolvedValue({ success: false, message: "Token invalide ou expiré." });
+
+      // when
+      const wrapper = mount(ActivateAccountView);
+      await flushPromises();
+
+      // then
+      expect(wrapper.text()).toContain("Token invalide ou expiré.");
+      expect(wrapper.text()).toContain("Retour à l'inscription");
+    });
+  });
+});


### PR DESCRIPTION
This pull request introduces account activation functionality to the authentication flow. It adds a new API adapter for activating user accounts, a dedicated view for handling activation via token, and comprehensive unit tests to ensure robust behavior. The router is updated to support navigation to the new activation view.

**Account Activation Feature:**

* Added a new `activateAccount` API adapter in `authentication.js` to handle account activation via token, including error handling for various response statuses.
* Created the `AuthenticationView.vue` view to process activation tokens, display loading and result states, and guide users to login or registration based on activation outcome.

**Routing Updates:**

* Registered the activation route in the router, linking `/authentication/activate` to the new activation view. [[1]](diffhunk://#diff-b748b8083a109dcaf84fc578f448369932cf15e8d16329a34749f99588b879ffR3) [[2]](diffhunk://#diff-b748b8083a109dcaf84fc578f448369932cf15e8d16329a34749f99588b879ffR24-R28)

**Testing Enhancements:**

* Added unit tests for the `activateAccount` adapter to verify correct endpoint calls, error handling, and token encoding. [[1]](diffhunk://#diff-c448239849aa86d8055bad4ffd1c21bedb0691c6c96c28e6995e3cd787c518dcL3-R3) [[2]](diffhunk://#diff-c448239849aa86d8055bad4ffd1c21bedb0691c6c96c28e6995e3cd787c518dcR136-R234)
* Added unit tests for `AuthenticationView.vue` to ensure correct UI and logic for various activation scenarios, including missing token, loading state, successful activation, and error cases.