### PR TITLE
tech: Use the web hash history for router of front apps

### DIFF
--- a/admin/src/router/index.js
+++ b/admin/src/router/index.js
@@ -1,7 +1,7 @@
-import { createRouter, createWebHistory } from "vue-router";
+import { createRouter, createWebHashHistory } from "vue-router";
 
 const router = createRouter({
-  history: createWebHistory(import.meta.env.BASE_URL),
+  history: createWebHashHistory(import.meta.env.BASE_URL),
   routes: [],
 });
 

--- a/web/src/router/index.js
+++ b/web/src/router/index.js
@@ -1,11 +1,11 @@
-import { createRouter, createWebHistory } from "vue-router";
+import { createRouter, createWebHashHistory } from "vue-router";
 
 import ActivateAccountView from "@/views/authentication/ActivateAccountView.vue";
 import LoginView from "@/views/authentication/LoginView.vue";
 import RegisterView from "@/views/authentication/RegisterView.vue";
 
 const router = createRouter({
-  history: createWebHistory(import.meta.env.BASE_URL),
+  history: createWebHashHistory(import.meta.env.BASE_URL),
   routes: [
     {
       path: "/",


### PR DESCRIPTION
This pull request updates the routing configuration for both the admin and web applications. The main change is switching from using HTML5 history mode to hash-based routing, which can help avoid server-side configuration issues and improve compatibility with static file hosting.

Routing configuration updates:

* Changed the router history mode from `createWebHistory` to `createWebHashHistory` in `admin/src/router/index.js` to use hash-based routing.
* Changed the router history mode from `createWebHistory` to `createWebHashHistory` in `web/src/router/index.js` to use hash-based routing.