### PR TITLE
tech: Setup pgadmin to visualize database

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -8,3 +8,37 @@ services:
       - ./api/.env
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
+
+  pgadmin:
+    image: dpage/pgadmin4:latest
+    container_name: kompagnon-pgadmin
+    ports:
+      - '${PGADMIN_PORT:-8080}:80'
+    environment:
+      PGADMIN_DEFAULT_EMAIL: '${PGADMIN_DEFAULT_EMAIL:-admin@kompagnon.dev}'
+      PGADMIN_DEFAULT_PASSWORD: '${PGADMIN_DEFAULT_PASSWORD:-admin}'
+    depends_on:
+      - postgres
+    volumes:
+      - pgadmin-data:/var/lib/pgadmin
+
+  pgadmin-init:
+    image: alpine:latest
+    container_name: kompagnon-pgadmin-init
+    depends_on:
+      - pgadmin
+    volumes:
+      - pgadmin-data:/var/lib/pgadmin
+      - ./scripts/pgadmin/init-create-server.sh:/usr/local/bin/init-create-server.sh:ro
+    environment:
+      PGADMIN_DEFAULT_EMAIL: '${PGADMIN_DEFAULT_EMAIL:-admin@kompagnon.dev}'
+      PGADMIN_DEFAULT_PASSWORD: '${PGADMIN_DEFAULT_PASSWORD:-admin}'
+      PG_HOST: postgres
+      PG_PORT: '5432'
+      PG_DB: kompagnon
+      PG_USER: postgres
+    entrypoint: ["/bin/sh", "/usr/local/bin/init-create-server.sh"]
+    restart: "no"
+
+volumes:
+  pgadmin-data: {}

--- a/scripts/pgadmin/init-create-server.sh
+++ b/scripts/pgadmin/init-create-server.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+# Init pgAdmin (dev)
+# -> uniquement servers.json (méthode officielle)
+
+set -eu
+
+PGADMIN_DATA_DIR=${PGADMIN_DATA_DIR:-/var/lib/pgadmin}
+
+PG_HOST=${PG_HOST:-postgres}
+PG_PORT=${PG_PORT:-5432}
+PG_DB=${PG_DB:-kompagnon}
+PG_USER=${PG_USER:-postgres}
+
+log() { printf "%s\n" "[init-pgadmin] $*"; }
+
+target_file="$PGADMIN_DATA_DIR/servers.json"
+
+log "Writing servers.json to $target_file"
+mkdir -p "$PGADMIN_DATA_DIR"
+
+cat > "$target_file" <<JSON
+{
+  "Servers": {
+    "1": {
+      "Name": "kompagnon-postgres",
+      "Group": "Servers",
+      "Host": "$PG_HOST",
+      "Port": $PG_PORT,
+      "MaintenanceDB": "$PG_DB",
+      "Username": "$PG_USER",
+      "SSLMode": "prefer",
+      "Comment": "Auto-created (servers.json)"
+    }
+  }
+}
+JSON
+
+log "servers.json written successfully."


### PR DESCRIPTION
## Problem
We need to have a solution to visualize the database and understand some data.

## Solution
Add the pgadmin service to visualize the database content and facilitate the data manipulation.

## Test
Run the configuration script
```shell
npm run configure
```
Goto http://localhost:8080 and login with admin@kompagnon.dev and admin for mdp.
Check that you can access to the server and see users seeded when the configuration has run.