### PR TITLE
feat(api): add auth middleware to verify token (closes #358)

### DIFF
--- a/api/src/shared/infrastructure/middlewares/auth-middleware.js
+++ b/api/src/shared/infrastructure/middlewares/auth-middleware.js
@@ -1,0 +1,62 @@
+import { logger } from "../../../../logger.js";
+import { findUserById } from "../../../identities-access-management/repositories/user-repository.js";
+import { decodedToken } from "../../../identities-access-management/services/token-service.js";
+
+/**
+ * Authentication middleware that verifies the JWT token and fetches user data.
+ * @param {object} req - Express request object
+ * @param {object} res - Express response object
+ * @param {Function} next - Express next middleware function
+ * @returns {Promise<void>}
+ */
+export async function authMiddleware(req, res, next) {
+  try {
+    const authHeader = req.headers.authorization;
+
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      return res.status(401).json({ message: "Authentication required" });
+    }
+
+    const token = authHeader.split(" ")[1];
+
+    if (!token) {
+      return res.status(401).json({ message: "Invalid token format" });
+    }
+
+    let decoded;
+    try {
+      decoded = decodedToken(token);
+    } catch (error) {
+      // The decodedToken service already throws an error with proper messaging
+      return res.status(401).json({ message: error.message });
+    }
+
+    if (!decoded || !decoded.userId) {
+      return res.status(401).json({ message: "Invalid token payload" });
+    }
+
+    const user = await findUserById(decoded.userId);
+
+    if (!user) {
+      return res.status(401).json({ message: "User not found" });
+    }
+
+    if (!user.isActive) {
+      return res.status(401).json({ message: "User account is inactive" });
+    }
+
+    // Attach user information to request
+    req.auth = {
+      userId: user.id,
+      firstname: user.firstname,
+      lastname: user.lastname,
+      email: user.email,
+      userType: user.userType,
+    };
+
+    next();
+  } catch (error) {
+    logger.error(`Error in authMiddleware: ${error}`);
+    return res.status(500).json({ message: "Internal server error during authentication" });
+  }
+}

--- a/api/tests/shared/integration/infrastructure/middlewares/auth-middleware.test.js
+++ b/api/tests/shared/integration/infrastructure/middlewares/auth-middleware.test.js
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from "vitest";
+
+import databaseBuilder from "../../../../../db/database-builder/index.js";
+import { encodedToken } from "../../../../../src/identities-access-management/services/token-service.js";
+import { authMiddleware } from "../../../../../src/shared/infrastructure/middlewares/auth-middleware.js";
+
+function buildReqRes() {
+  const req = { headers: {} };
+  const res = {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn(),
+  };
+  const next = vi.fn();
+  return { req, res, next };
+}
+
+describe("Integration | Shared | Infrastructure | Middlewares | Auth Middleware", () => {
+  describe("when no authorization header is provided", () => {
+    it("should return 401", async () => {
+      // given
+      const { req, res, next } = buildReqRes();
+
+      // when
+      await authMiddleware(req, res, next);
+
+      // then
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith({ message: "Authentication required" });
+      expect(next).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when authorization header is missing 'Bearer ' prefix", () => {
+    it("should return 401", async () => {
+      // given
+      const { req, res, next } = buildReqRes();
+      req.headers.authorization = "Basic token123";
+
+      // when
+      await authMiddleware(req, res, next);
+
+      // then
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith({ message: "Authentication required" });
+      expect(next).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when token is missing after 'Bearer '", () => {
+    it("should return 401", async () => {
+      // given
+      const { req, res, next } = buildReqRes();
+      req.headers.authorization = "Bearer ";
+
+      // when
+      await authMiddleware(req, res, next);
+
+      // then
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith({ message: "Invalid token format" });
+      expect(next).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when token is invalid or expired", () => {
+    it("should return 401", async () => {
+      // given
+      const { req, res, next } = buildReqRes();
+      req.headers.authorization = "Bearer invalid-token";
+
+      // when
+      await authMiddleware(req, res, next);
+
+      // then
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(next).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when token does not contain a userId", () => {
+    it("should return 401", async () => {
+      // given
+      const { req, res, next } = buildReqRes();
+      const token = encodedToken({ someOtherData: "xyz" });
+      req.headers.authorization = `Bearer ${token}`;
+
+      // when
+      await authMiddleware(req, res, next);
+
+      // then
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith({ message: "Invalid token payload" });
+      expect(next).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when user referenced in token does not exist in database", () => {
+    it("should return 401", async () => {
+      // given
+      const { req, res, next } = buildReqRes();
+      const token = encodedToken({ userId: 99999 });
+      req.headers.authorization = `Bearer ${token}`;
+
+      // when
+      await authMiddleware(req, res, next);
+
+      // then
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith({ message: "User not found" });
+      expect(next).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when user account is inactive", () => {
+    it("should return 401", async () => {
+      // given
+      const { req, res, next } = buildReqRes();
+      const user = await databaseBuilder.factory.buildUser({ isActive: false });
+      const token = encodedToken({ userId: user.id });
+      req.headers.authorization = `Bearer ${token}`;
+
+      // when
+      await authMiddleware(req, res, next);
+
+      // then
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith({ message: "User account is inactive" });
+      expect(next).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when token and user are valid", () => {
+    it("should call next() and populate req.auth", async () => {
+      // given
+      const { req, res, next } = buildReqRes();
+      const user = await databaseBuilder.factory.buildUser({
+        firstname: "John",
+        lastname: "Doe",
+        email: "john@example.com",
+        isActive: true,
+      });
+      const token = encodedToken({ userId: user.id });
+      req.headers.authorization = `Bearer ${token}`;
+
+      // when
+      await authMiddleware(req, res, next);
+
+      // then
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(req.auth).toBeDefined();
+      expect(req.auth.userId).toBe(user.id);
+      expect(req.auth.firstname).toBe("John");
+      expect(req.auth.lastname).toBe("Doe");
+      expect(req.auth.email).toBe("john@example.com");
+    });
+  });
+});


### PR DESCRIPTION
This pull request addresses issue #358.

### Description
Implemented a middleware for the API that verifies the incoming `authorization` header for protected routes.

The middleware handles the following operations:
- Recovers the token from the `authorization` header.
- Decodes the token to retrieve the `userId`.
- Validates the token payload.
- Checks the database for the `userId` to ensure the user exists and their account is active.
- Injects an `auth` object into the `req` object containing `userId`, `firstname`, `lastname`, `email`, and `userType`.
- Returns an HTTP 401 Unauthorized status if any of the above checks fail.

### Changes
- **New Middleware**: `auth-middleware.js` located in `api/src/shared/infrastructure/middlewares/ `
- **Unit Tests**: `auth-middleware.test.js` located in `api/tests/unit/shared/infrastructure/middlewares/ `

### Related Issues
Closes #358