### PR TITLE
fix: Convert the date to respect format

### DIFF
--- a/api/src/identities-access-management/controllers/register-user-controller.js
+++ b/api/src/identities-access-management/controllers/register-user-controller.js
@@ -13,9 +13,53 @@ const registerUserSchema = celebrate({
     firstname: Joi.string().required(),
     lastname: Joi.string().required(),
     password: Joi.string().required(),
-    birthday: Joi.string().required(),
+    birthday: Joi.alternatives()
+      .try(
+        Joi.string().pattern(/^\d{2}\/\d{2}\/\d{4}$/), // DD/MM/YYYY
+        Joi.string().isoDate(), // ISO 8601 (e.g., YYYY-MM-DD)
+      )
+      .required(),
   }),
 });
+
+/**
+ * Normalize birthday into YYYY-MM-DD and validate that it is a real date.
+ * Accepts either DD/MM/YYYY or YYYY-MM-DD (ISO) formats.
+ * @param {string} birthday
+ * @returns {string} Normalized birthday in YYYY-MM-DD format
+ * @throws {Error} with statusCode 400 for invalid formats or dates
+ */
+function normalizeBirthday(birthday) {
+  // Accept ISO format as-is if it matches YYYY-MM-DD
+  if (/^\d{4}-\d{2}-\d{2}$/.test(birthday)) {
+    return birthday;
+  }
+
+  // Accept DD/MM/YYYY and convert to YYYY-MM-DD
+  const match = /^(\d{2})\/(\d{2})\/(\d{4})$/.exec(birthday);
+  if (!match) {
+    const error = new Error("Invalid birthday format");
+    error.statusCode = 400;
+    throw error;
+  }
+
+  const [, day, month, year] = match;
+  const date = new Date(`${year}-${month}-${day}T00:00:00Z`);
+
+  const isInvalidDate =
+    Number.isNaN(date.getTime()) ||
+    date.getUTCFullYear().toString() !== year ||
+    String(date.getUTCMonth() + 1).padStart(2, "0") !== month ||
+    String(date.getUTCDate()).padStart(2, "0") !== day;
+
+  if (isInvalidDate) {
+    const error = new Error("Invalid birthday date");
+    error.statusCode = 400;
+    throw error;
+  }
+
+  return `${year}-${month}-${day}`;
+}
 
 /**
  * Register User Controller
@@ -40,10 +84,26 @@ async function registerUserController(
   try {
     const { firstname, lastname, email, password, birthday } = req.body;
     const hashedPassword = await generatePasswordService(password);
-    const userId = await createUserRepository({ firstname, lastname, email, birthday, hashedPassword });
-    await sendMailActivationService({ firstname, lastname, token: encodedTokenService({ userId }), email });
+    const normalizedBirthday = normalizeBirthday(birthday);
+    const userId = await createUserRepository({
+      firstname,
+      lastname,
+      email,
+      hashedPassword,
+      birthday: normalizedBirthday,
+    });
+    await sendMailActivationService({
+      firstname,
+      lastname,
+      token: encodedTokenService({ userId }),
+      email,
+    });
     return res.status(201).send();
   } catch (error) {
+    if (error.statusCode && error.statusCode >= 400 && error.statusCode < 500) {
+      logger.warn(`User registration rejected: ${error.message}`);
+      return res.status(error.statusCode).json({ message: error.message });
+    }
     logger.error(`User registration failed: ${error}`);
     return res.status(500).json({ message: ERRORS.INTERNAL_SERVER_ERROR });
   }

--- a/api/tests/identities-access-management/acceptance/authentication-routes.test.js
+++ b/api/tests/identities-access-management/acceptance/authentication-routes.test.js
@@ -8,23 +8,44 @@ import { encodedToken } from "../../../src/identities-access-management/services
 
 describe("Acceptance | Identities Access Management | Routes | Authentication routes", () => {
   describe("POST /api/authentication/register", () => {
-    it("should return 201 http code status and create user", async () => {
-      // given
-      const body = {
-        firstname: "John",
-        lastname: "Doe",
-        email: "john.doe@example.net",
-        password: "password",
-        birthday: "01/01/2001",
-      };
+    describe("201 http status", () => {
+      it("should return 201 http code status and create user with simple date", async () => {
+        // given
+        const body = {
+          firstname: "John",
+          lastname: "Doe",
+          email: "john.doe@example.net",
+          password: "password",
+          birthday: "01/01/2001",
+        };
 
-      // when
-      const response = await request(server).post("/api/authentication/register").send(body);
+        // when
+        const response = await request(server).post("/api/authentication/register").send(body);
 
-      // then
-      expect(response.status).toBe(201);
-      const user = await knex("users").where({ email: body.email }).first();
-      expect(user).toBeDefined();
+        // then
+        expect(response.status).toBe(201);
+        const user = await knex("users").where({ email: body.email }).first();
+        expect(user).toBeDefined();
+      });
+
+      it("should return 201 http code status and create user with complex date", async () => {
+        // given
+        const body = {
+          firstname: "John",
+          lastname: "Doe",
+          email: "john.doe@example.net",
+          password: "password",
+          birthday: "14/02/2003",
+        };
+
+        // when
+        const response = await request(server).post("/api/authentication/register").send(body);
+
+        // then
+        expect(response.status).toBe(201);
+        const user = await knex("users").where({ email: body.email }).first();
+        expect(user).toBeDefined();
+      });
     });
 
     it("should return 400 if object validation failed", async () => {

--- a/api/tests/identities-access-management/unit/controllers/register-user-controller.test.js
+++ b/api/tests/identities-access-management/unit/controllers/register-user-controller.test.js
@@ -29,6 +29,7 @@ describe("Unit | Identities Access Management | Controller | Register new user",
         lastname: "Doe",
         email: "john.doe@example.net",
         password: "Password",
+        birthday: "17/04/2015",
       },
     };
     createUserRepository.mockResolvedValue(123);
@@ -45,6 +46,7 @@ describe("Unit | Identities Access Management | Controller | Register new user",
       lastname: req.body.lastname,
       email: req.body.email,
       hashedPassword: "hashedPassword",
+      birthday: "2015-04-17",
     });
     expect(sendMailActivationService).toHaveBeenCalledWith({ firstname: req.body.firstname, lastname: req.body.lastname, token: "token", email: req.body.email });
     expect(res.status).toHaveBeenCalledWith(201);
@@ -60,6 +62,7 @@ describe("Unit | Identities Access Management | Controller | Register new user",
           lastname: "Doe",
           email: "john.doe@example.net",
           password: "Password",
+          birthday: "17/04/2015",
         },
       };
       const error = new Error("Database connection failed");


### PR DESCRIPTION
This pull request updates the user registration logic to standardize the handling of the `birthday` field and expands the test coverage to ensure correct processing of different date formats. The main changes include modifying how the `birthday` is parsed and stored, and adding new tests to verify this behavior.

**User registration logic improvements:**

* The `birthday` field is now parsed from the request body using `split("/")` and reformatted to the `YYYY-MM-DD` format before storing it in the database. This ensures consistent date storage regardless of the input format.

**Testing enhancements:**

* The registration tests are reorganized, and a new test case is added to verify that user registration works correctly when a complex date format (e.g., "14/02/2003") is provided for the `birthday` field. [[1]](diffhunk://#diff-282b00888bec4c359e18c111a402b1659908f5b3662c98d7eac806ed0653a428L11-R12) [[2]](diffhunk://#diff-282b00888bec4c359e18c111a402b1659908f5b3662c98d7eac806ed0653a428R31-R50)