### PR TITLE
tech: Add the edp5 action to update node

### DIFF
--- a/.github/workflows/update-node-version.yml
+++ b/.github/workflows/update-node-version.yml
@@ -1,0 +1,19 @@
+name: update-node-version
+
+on:
+  schedule:
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
+
+permissions:
+    contents: write
+    pull-requests: write
+
+jobs:
+  update-node:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: edp5/edp5-actions/update-node-version@v1.1.5
+        with:
+          token: ${{ secrets.SERVICE_TOKEN }}


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate updating the Node.js version in the repository. The workflow is scheduled to run monthly and can also be triggered manually.

Automation:

* Added a new workflow file, `.github/workflows/update-node-version.yml`, which uses the `edp5/edp5-actions/update-node-version` action to update the Node.js version on a monthly schedule or via manual dispatch.