### PR TITLE
fix: Use version in auto merge action

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -17,6 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Call auto merge
-        uses: edp5/edp5-actions/auto-merge@main
+        uses: edp5/edp5-actions/auto-merge@v1.2.1
         with:
             token: ${{ secrets.SERVICE_TOKEN }}


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow by pinning the `auto-merge` action to a specific version (`v1.2.0`) instead of using the `main` branch. This improves the stability and predictability of the workflow.