### PR TITLE
feat: add profile section in web app

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -4,6 +4,7 @@ import express from "express";
 
 import { logger } from "./logger.js";
 import authenticationRoutes from "./src/identities-access-management/routes/authentication-routes.js";
+import usersRoutes from "./src/identities-access-management/routes/users-routes.js";
 import fronts from "./src/shared/fronts/fronts-routes.js";
 import health from "./src/shared/health/routes.js";
 import swaggerRoute from "./swagger.js";
@@ -26,6 +27,7 @@ server.use((req, res, next) => {
 server.use(fronts);
 server.use(health);
 server.use(authenticationRoutes);
+server.use(usersRoutes);
 
 // do not write routes under this line
 // eslint-disable-next-line no-unused-vars

--- a/api/src/identities-access-management/controllers/get-user-profile-controller.js
+++ b/api/src/identities-access-management/controllers/get-user-profile-controller.js
@@ -1,0 +1,47 @@
+import { logger } from "../../../logger.js";
+import ERRORS from "../errors.js";
+import { findUserById } from "../repositories/user-repository.js";
+
+/**
+ * Return authenticated user's profile.
+ * Requires authMiddleware to populate req.auth.userId.
+ * @param {object} req - Express request containing the authenticated user id on req.auth.
+ * @param {object} res - Express response used to return profile payload or an error.
+ * @param {Function} next - Express next middleware function.
+ * @param {Function} findUserProfileByIdRepository - Function to fetch the profile by authenticated user id.
+ * @returns {Promise<object>} HTTP response with user profile data or internal server error.
+ */
+async function getUserProfileController(req, res, next, findUserProfileByIdRepository = findUserById) {
+  try {
+    const { userId } = req.auth;
+
+    if (!userId) {
+      logger.error("Error in getUserProfileController: missing authenticated user id");
+      return res.status(500).json({ message: ERRORS.INTERNAL_SERVER_ERROR });
+    }
+
+    const userProfile = await findUserProfileByIdRepository(userId);
+
+    if (!userProfile) {
+      return res.status(401).json({ message: "User not found" });
+    }
+
+    return res.status(200).json({
+      data: {
+        userId: userProfile.id,
+        firstname: userProfile.firstname,
+        lastname: userProfile.lastname,
+        email: userProfile.email,
+        birthday: userProfile.birthday,
+        genre: userProfile.genre,
+        role: userProfile.role,
+        disabilities: userProfile.disabilities,
+      },
+    });
+  } catch (error) {
+    logger.error(`Error in getUserProfileController: ${error}`);
+    return res.status(500).json({ message: ERRORS.INTERNAL_SERVER_ERROR });
+  }
+}
+
+export { getUserProfileController };

--- a/api/src/identities-access-management/controllers/register-user-controller.js
+++ b/api/src/identities-access-management/controllers/register-user-controller.js
@@ -25,7 +25,7 @@ const registerUserSchema = celebrate({
 /**
  * Normalize birthday into YYYY-MM-DD and validate that it is a real date.
  * Accepts either DD/MM/YYYY or YYYY-MM-DD (ISO) formats.
- * @param {string} birthday - Birthday string in either DD/MM/YYYY or YYYY-MM-DD format
+ * @param {string} birthday - Birthday value provided by the client in DD/MM/YYYY or YYYY-MM-DD format.
  * @returns {string} Normalized birthday in YYYY-MM-DD format
  * @throws {Error} with statusCode 400 for invalid formats or dates
  */

--- a/api/src/identities-access-management/routes/users-routes.js
+++ b/api/src/identities-access-management/routes/users-routes.js
@@ -1,0 +1,72 @@
+import express from "express";
+
+import { authMiddleware } from "../../shared/infrastructure/middlewares/auth-middleware.js";
+import { getUserProfileController } from "../controllers/get-user-profile-controller.js";
+
+const usersRoutes = express.Router();
+
+/**
+ * @swagger
+ * /api/authentication/profile:
+ *   get:
+ *     summary: Get the authenticated user's profile
+ *     description: Returns the profile information for the authenticated user.
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: User profile retrieved successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *       401:
+ *         description: Unauthorized
+ *       500:
+ *         description: Internal server error
+ */
+
+/**
+ * @swagger
+ * /api/authentication/profile:
+ *   get:
+ *     summary: Get authenticated user profile
+ *     description: Returns profile information for the authenticated user.
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: User profile retrieved successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     userId:
+ *                       type: integer
+ *                       example: 1
+ *                     firstname:
+ *                       type: string
+ *                       example: John
+ *                     lastname:
+ *                       type: string
+ *                       example: Doe
+ *                     email:
+ *                       type: string
+ *                       format: email
+ *                       example: john.doe@example.net
+ *                     birthday:
+ *                       type: string
+ *                       format: date
+ *                       example: 1990-05-15
+ *       401:
+ *         description: Unauthorized
+ *       500:
+ *         description: Internal server error
+ */
+usersRoutes.get("/api/users/profile", authMiddleware, getUserProfileController);
+
+export default usersRoutes;

--- a/api/tests/identities-access-management/acceptance/users-routes.test.js
+++ b/api/tests/identities-access-management/acceptance/users-routes.test.js
@@ -1,0 +1,47 @@
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+
+import databaseBuilder from "../../../db/database-builder/index.js";
+import server from "../../../server.js";
+import { encodedToken } from "../../../src/identities-access-management/services/token-service.js";
+
+describe("GET /api/users/profile", () => {
+  it("should return 200 and user profile when token is valid", async () => {
+    // given
+    const user = await databaseBuilder.factory.buildUser({
+      firstname: "Jane",
+      lastname: "Doe",
+      email: "jane.doe@example.com",
+      birthday: "1990-05-15",
+      isActive: true,
+    });
+    const token = encodedToken({ userId: user.id, userType: user.userType });
+
+    // when
+    const response = await request(server)
+      .get("/api/users/profile")
+      .set("Authorization", `Bearer ${token}`);
+
+    // then
+    expect(response.status).toBe(200);
+    expect(response.body.data).toEqual({
+      userId: user.id,
+      firstname: user.firstname,
+      lastname: user.lastname,
+      email: user.email,
+      birthday: "1990-05-15",
+      role: null,
+      genre: null,
+      disabilities: null,
+    });
+  });
+
+  it("should return 401 when authorization header is missing", async () => {
+    // when
+    const response = await request(server).get("/api/users/profile");
+
+    // then
+    expect(response.status).toBe(401);
+    expect(response.body).toEqual({ message: "Authentication required" });
+  });
+});

--- a/api/tests/identities-access-management/unit/controllers/get-user-profile-controller.test.js
+++ b/api/tests/identities-access-management/unit/controllers/get-user-profile-controller.test.js
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getUserProfileController } from "../../../../src/identities-access-management/controllers/get-user-profile-controller.js";
+import ERRORS from "../../../../src/identities-access-management/errors.js";
+
+describe("Unit | Identities Access Management | Controller | Get user profile controller", () => {
+  let res, findUserProfileByIdRepository, next;
+
+  beforeEach(() => {
+    findUserProfileByIdRepository = vi.fn();
+    res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+  });
+
+  it("should return 200 with authenticated profile", async () => {
+    // given
+    const req = {
+      auth: {
+        userId: 42,
+      },
+    };
+    findUserProfileByIdRepository.mockResolvedValue({
+      id: 42,
+      firstname: "Jane",
+      lastname: "Doe",
+      email: "jane.doe@example.com",
+      birthday: "1990-05-15",
+      genre: "nb",
+      role: "ttt",
+      disabilities: ["a", "b"],
+    });
+
+    // when
+    await getUserProfileController(req, res, next, findUserProfileByIdRepository);
+
+    // then
+    expect(findUserProfileByIdRepository).toHaveBeenCalledWith(42);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      data: {
+        userId: 42,
+        firstname: "Jane",
+        lastname: "Doe",
+        email: "jane.doe@example.com",
+        birthday: "1990-05-15",
+        genre: "nb",
+        role: "ttt",
+        disabilities: ["a", "b"],
+      },
+    });
+  });
+
+  it("should return 401 when authenticated user is not found", async () => {
+    // given
+    const req = {
+      auth: {
+        userId: 42,
+      },
+    };
+    findUserProfileByIdRepository.mockResolvedValue(null);
+
+    // when
+    await getUserProfileController(req, res, next, findUserProfileByIdRepository);
+
+    // then
+    expect(findUserProfileByIdRepository).toHaveBeenCalledWith(42);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ message: "User not found" });
+  });
+
+  it("should return 500 when req.auth is missing", async () => {
+    // given
+    const req = {};
+
+    // when
+    await getUserProfileController(req, res, next, findUserProfileByIdRepository);
+
+    // then
+    expect(findUserProfileByIdRepository).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ message: ERRORS.INTERNAL_SERVER_ERROR });
+  });
+
+  it("should return 500 when the repository fails", async () => {
+    // given
+    const req = {
+      auth: {
+        userId: 42,
+      },
+    };
+    findUserProfileByIdRepository.mockRejectedValue(new Error("Database down"));
+
+    // when
+    await getUserProfileController(req, res, next, findUserProfileByIdRepository);
+
+    // then
+    expect(findUserProfileByIdRepository).toHaveBeenCalledWith(42);
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ message: ERRORS.INTERNAL_SERVER_ERROR });
+  });
+});

--- a/web/src/adapters/users.js
+++ b/web/src/adapters/users.js
@@ -1,0 +1,40 @@
+const USERS_URL = "/api/users/";
+
+async function getUserProfile({ token }) {
+  try {
+    const response = await fetch(`${USERS_URL}profile`, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    if (!response.ok) {
+      if (response.status === 401) {
+        return {
+          success: false,
+          errorCode: "SESSION_EXPIRED",
+          message: "Session expirée. Merci de vous reconnecter.",
+        };
+      }
+
+      return {
+        success: false,
+        message: "Impossible de charger le profil utilisateur.",
+      };
+    }
+
+    const data = await response.json();
+    return {
+      success: true,
+      profile: data?.data,
+    };
+  } catch {
+    return {
+      success: false,
+      message: "Impossible de joindre le serveur. Veuillez réessayer plus tard.",
+    };
+  }
+}
+
+export { getUserProfile };

--- a/web/src/constants.js
+++ b/web/src/constants.js
@@ -1,0 +1,9 @@
+export const USER_ROLES = {
+  valid: "Accompagnateur",
+  invalid: "Personne handicapé",
+};
+
+export const USER_GENRE = {
+  F: "Mme",
+  M: "Monsieur",
+};

--- a/web/src/router/index.js
+++ b/web/src/router/index.js
@@ -1,9 +1,11 @@
 import { createRouter, createWebHashHistory } from "vue-router";
 
+import { useAuthStore } from "@/stores/auth.js";
 import ActivateAccountView from "@/views/authentication/ActivateAccountView.vue";
 import LoginView from "@/views/authentication/LoginView.vue";
 import RegisterView from "@/views/authentication/RegisterView.vue";
 import HomeView from "@/views/HomeView.vue";
+import ProfileView from "@/views/ProfileView.vue";
 
 const router = createRouter({
   history: createWebHashHistory(import.meta.env.BASE_URL),
@@ -16,6 +18,9 @@ const router = createRouter({
       path: "/home",
       name: "home",
       component: HomeView,
+      meta: {
+        requiresAuth: true,
+      },
     },
     {
       path: "/login",
@@ -32,7 +37,33 @@ const router = createRouter({
       name: "activate-account",
       component: ActivateAccountView,
     },
+    {
+      path: "/profile",
+      name: "profile",
+      component: ProfileView,
+      meta: {
+        requiresAuth: true,
+      },
+    },
   ],
+});
+
+router.beforeEach((to) => {
+  if (!to.matched.some((route) => route.meta.requiresAuth)) {
+    return true;
+  }
+
+  const authStore = useAuthStore();
+  if (authStore.token) {
+    return true;
+  }
+
+  return {
+    name: "login",
+    query: {
+      redirect: to.fullPath,
+    },
+  };
 });
 
 export default router;

--- a/web/src/views/ProfileView.vue
+++ b/web/src/views/ProfileView.vue
@@ -1,0 +1,108 @@
+<script setup>
+import { onMounted, ref } from "vue";
+import { useRouter } from "vue-router";
+
+import { getUserProfile } from "@/adapters/users.js";
+import { USER_GENRE } from "@/constants.js";
+import { useAuthStore } from "@/stores/auth.js";
+
+import { USER_ROLE } from "../../../api/src/shared/constants.js";
+
+const router = useRouter();
+const authStore = useAuthStore();
+const profile = ref(null);
+const errorMessage = ref("");
+const isLoading = ref(true);
+
+onMounted(async () => {
+  const token = authStore.token;
+
+  if (!token) {
+    router.push({ name: "login" });
+    return;
+  }
+
+  const result = await getUserProfile({ token });
+  if (result.success) {
+    profile.value = result.profile;
+  } else {
+    errorMessage.value = result.message ?? "Impossible de charger le profil.";
+    if (result.errorCode === "SESSION_EXPIRED") {
+      authStore.logout();
+      router.push({ name: "login" });
+    }
+  }
+
+  isLoading.value = false;
+});
+</script>
+
+<template>
+  <section class="profile-view">
+    <h1>Mon profil</h1>
+
+    <p v-if="isLoading">
+      Chargement du profil...
+    </p>
+
+    <p
+      v-else-if="errorMessage"
+      class="feedback error"
+      role="alert"
+      aria-live="assertive"
+    >
+      {{ errorMessage }}
+    </p>
+
+    <dl
+      v-else-if="profile"
+      class="profile-details"
+    >
+      <dd>{{ USER_GENRE[profile.genre] }}</dd>
+      <dt>Prénom</dt>
+      <dd>{{ profile.firstname }}</dd>
+
+      <dt>Nom</dt>
+      <dd>{{ profile.lastname }}</dd>
+
+      <dt>Email</dt>
+      <dd>{{ profile.email }}</dd>
+
+      <dt>Date de naissance</dt>
+      <dd>{{ profile.birthday }}</dd>
+
+      <dt>Vous êtes</dt>
+      <dd>{{ USER_ROLE[profile.role] }}</dd>
+    </dl>
+  </section>
+</template>
+
+<style scoped>
+.profile-view {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+}
+
+.profile-details {
+  display: grid;
+  grid-template-columns: 160px 1fr;
+  row-gap: 0.75rem;
+  column-gap: 1rem;
+}
+
+.profile-details dt {
+  font-weight: 700;
+}
+
+.profile-details dd {
+  margin: 0;
+}
+
+.feedback.error {
+  background-color: #fee2e2;
+  color: #991b1b;
+  padding: 0.75rem;
+  border-radius: 4px;
+}
+</style>

--- a/web/src/views/authentication/LoginView.vue
+++ b/web/src/views/authentication/LoginView.vue
@@ -1,12 +1,13 @@
 <script setup>
 import { reactive, ref } from "vue";
-import { useRouter } from "vue-router";
+import { useRoute, useRouter } from "vue-router";
 
 import { loginUser } from "@/adapters/authentication.js";
 import PasswordComponent from "@/components/PasswordComponent.vue";
 import { useAuthStore } from "@/stores/auth.js";
 
 const router = useRouter();
+const route = useRoute();
 const authStore = useAuthStore();
 
 function initialFormState() {
@@ -32,7 +33,11 @@ async function handleSubmit() {
 
   if (result.success) {
     authStore.setAuth(result.token, result.userId);
-    router.push({ name: "home" });
+    const redirectTarget = typeof route.query.redirect === "string"
+      ? route.query.redirect
+      : { name: "home" };
+
+    router.push(redirectTarget);
   } else {
     errorMessage.value =
       result.message ?? "Une erreur est survenue lors de la connexion.";

--- a/web/tests/unit/adapters/users.spec.js
+++ b/web/tests/unit/adapters/users.spec.js
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { getUserProfile } from "@/adapters/users.js";
+
+describe("Unit | Adapters | Users", () => {
+  describe("#getUserProfile", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("should return profile data on success", async () => {
+      // given
+      vi.spyOn(global, "fetch").mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: { firstname: "John", lastname: "Doe", email: "john@example.com", birthday: "1990-05-15" } }),
+      });
+
+      // when
+      const result = await getUserProfile({ token: "valid-token" });
+
+      // then
+      expect(result).toEqual({
+        success: true,
+        profile: {
+          firstname: "John",
+          lastname: "Doe",
+          email: "john@example.com",
+          birthday: "1990-05-15",
+        },
+      });
+      expect(fetch).toHaveBeenCalledWith("/api/users/profile", {
+        method: "GET",
+        headers: {
+          Authorization: "Bearer valid-token",
+        },
+      });
+    });
+
+    it("should return a dedicated message when token is invalid", async () => {
+      // given
+      vi.spyOn(global, "fetch").mockResolvedValue({
+        ok: false,
+        status: 401,
+      });
+
+      // when
+      const result = await getUserProfile({ token: "invalid-token" });
+
+      // then
+      expect(result).toEqual({
+        success: false,
+        errorCode: "SESSION_EXPIRED",
+        message: "Session expirée. Merci de vous reconnecter.",
+      });
+    });
+  });
+});

--- a/web/tests/unit/router/index.spec.js
+++ b/web/tests/unit/router/index.spec.js
@@ -1,8 +1,16 @@
-import { describe, expect, it } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it } from "vitest";
 
 import router from "@/router/index.js";
+import { useAuthStore } from "@/stores/auth.js";
 
 describe("Unit | Router", () => {
+  beforeEach(async () => {
+    localStorage.clear();
+    setActivePinia(createPinia());
+    await router.push({ name: "login" });
+  });
+
   describe("routes configuration", () => {
     it("should register the root redirect route", () => {
       // when
@@ -10,7 +18,6 @@ describe("Unit | Router", () => {
 
       // then
       expect(rootRoute).toBeDefined();
-      // TODO: update redirect to login route once it exists.
       expect(rootRoute?.redirect).toEqual({ name: "login" });
     });
 
@@ -21,6 +28,26 @@ describe("Unit | Router", () => {
       // then
       expect(registerRoute).toBeDefined();
       expect(registerRoute?.path).toBe("/register");
+    });
+
+    it("should register the profile route", () => {
+      // when
+      const profileRoute = router.getRoutes().find((route) => route.name === "profile");
+
+      // then
+      expect(profileRoute).toBeDefined();
+      expect(profileRoute?.path).toBe("/profile");
+      expect(profileRoute?.meta.requiresAuth).toBe(true);
+    });
+
+    it("should require authentication for the home route", () => {
+      // when
+      const homeRoute = router.getRoutes().find((route) => route.name === "home");
+
+      // then
+      expect(homeRoute).toBeDefined();
+      expect(homeRoute?.path).toBe("/home");
+      expect(homeRoute?.meta.requiresAuth).toBe(true);
     });
   });
 
@@ -84,5 +111,26 @@ describe("Unit | Router", () => {
 
     // cleanup
     router.removeRoute("testWithParam");
+  });
+
+  it("should redirect unauthenticated users from protected routes to login", async () => {
+    // when
+    await router.push({ name: "profile" });
+
+    // then
+    expect(router.currentRoute.value.name).toBe("login");
+    expect(router.currentRoute.value.query.redirect).toBe("/profile");
+  });
+
+  it("should allow authenticated users to access protected routes", async () => {
+    // given
+    const authStore = useAuthStore();
+    authStore.setAuth("jwt-token", 1);
+
+    // when
+    await router.push({ name: "profile" });
+
+    // then
+    expect(router.currentRoute.value.name).toBe("profile");
   });
 });

--- a/web/tests/unit/views/ProfileView.spec.js
+++ b/web/tests/unit/views/ProfileView.spec.js
@@ -1,0 +1,76 @@
+import { flushPromises, mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getUserProfile } from "@/adapters/users.js";
+import { useAuthStore } from "@/stores/auth.js";
+import ProfileView from "@/views/ProfileView.vue";
+
+vi.mock("@/adapters/users.js", () => ({
+  getUserProfile: vi.fn(),
+}));
+
+const mockPush = vi.fn();
+vi.mock("vue-router", () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+}));
+
+describe("Unit | Views | ProfileView", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setActivePinia(createPinia());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should display profile data when request succeeds", async () => {
+    // given
+    const authStore = useAuthStore();
+    authStore.setAuth("valid-token", 1);
+    getUserProfile.mockResolvedValue({
+      success: true,
+      profile: {
+        firstname: "Jane",
+        lastname: "Doe",
+        email: "jane.doe@example.com",
+        birthday: "1990-05-15",
+      },
+    });
+
+    // when
+    const wrapper = mount(ProfileView);
+    await flushPromises();
+
+    // then
+    expect(getUserProfile).toHaveBeenCalledWith({ token: "valid-token" });
+    expect(wrapper.text()).toContain("Jane");
+    expect(wrapper.text()).toContain("Doe");
+    expect(wrapper.text()).toContain("jane.doe@example.com");
+    expect(wrapper.text()).toContain("1990-05-15");
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("should clear token and redirect to login when session is expired", async () => {
+    // given
+    const authStore = useAuthStore();
+    authStore.setAuth("expired-token", 1);
+    getUserProfile.mockResolvedValue({
+      success: false,
+      errorCode: "SESSION_EXPIRED",
+      message: "Session expirée. Merci de vous reconnecter.",
+    });
+
+    // when
+    mount(ProfileView);
+    await flushPromises();
+
+    // then
+    expect(authStore.token).toBe(null);
+    expect(authStore.userId).toBe(null);
+    expect(mockPush).toHaveBeenCalledWith({ name: "login" });
+  });
+});

--- a/web/tests/unit/views/authentication/LoginView.spec.js
+++ b/web/tests/unit/views/authentication/LoginView.spec.js
@@ -11,10 +11,15 @@ vi.mock("@/adapters/authentication.js", () => ({
 }));
 
 const mockPush = vi.fn();
+const mockRoute = {
+  query: {},
+};
+
 vi.mock("vue-router", () => ({
   useRouter: () => ({
     push: mockPush,
   }),
+  useRoute: () => mockRoute,
   RouterLink: {
     template: "<a><slot /></a>",
   },
@@ -25,18 +30,31 @@ async function fillForm(wrapper) {
   await wrapper.get("input[name=\"password\"]").setValue("password123");
 }
 
+function mountLoginView() {
+  return mount(LoginView, {
+    global: {
+      stubs: {
+        RouterLink: {
+          template: "<a><slot /></a>",
+        },
+      },
+    },
+  });
+}
+
 describe("Unit | Views | Authentication | LoginView", () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     vi.clearAllMocks();
+    mockRoute.query = {};
   });
 
-  it("should store the token and redirect to home after a successful login", async () => {
+  it("should redirect to home page after a successful login", async () => {
     // given
     loginUser.mockResolvedValue({ success: true, token: "jwt-token", userId: 1 });
 
     // when
-    const wrapper = mount(LoginView);
+    const wrapper = mountLoginView();
     const authStore = useAuthStore();
     await fillForm(wrapper);
     await wrapper.find("form").trigger("submit");
@@ -60,7 +78,7 @@ describe("Unit | Views | Authentication | LoginView", () => {
     });
 
     // when
-    const wrapper = mount(LoginView);
+    const wrapper = mountLoginView();
     await fillForm(wrapper);
     await wrapper.find("form").trigger("submit");
     await flushPromises();
@@ -70,6 +88,21 @@ describe("Unit | Views | Authentication | LoginView", () => {
     expect(mockPush).not.toHaveBeenCalled();
   });
 
+  it("should redirect to the requested protected route after a successful login", async () => {
+    // given
+    mockRoute.query = { redirect: "/profile" };
+    loginUser.mockResolvedValue({ success: true, token: "jwt-token", userId: 1 });
+
+    // when
+    const wrapper = mountLoginView();
+    await fillForm(wrapper);
+    await wrapper.find("form").trigger("submit");
+    await flushPromises();
+
+    // then
+    expect(mockPush).toHaveBeenCalledWith("/profile");
+  });
+
   it("should show fallback error message when login fails without message", async () => {
     // given
     loginUser.mockResolvedValue({
@@ -77,7 +110,7 @@ describe("Unit | Views | Authentication | LoginView", () => {
     });
 
     // when
-    const wrapper = mount(LoginView);
+    const wrapper = mountLoginView();
     await fillForm(wrapper);
     await wrapper.find("form").trigger("submit");
     await flushPromises();
@@ -88,7 +121,7 @@ describe("Unit | Views | Authentication | LoginView", () => {
 
   it("should render registration link", async () => {
     // when
-    const wrapper = mount(LoginView);
+    const wrapper = mountLoginView();
 
     // then
     const link = wrapper.find("p.register-link");


### PR DESCRIPTION
## Summary
- add `GET /api/authentication/profile` route protected by auth middleware
- add `ProfileView` and `/profile` route in web app
- store token on login and load connected user profile

## Test plan
- [x] `cd web && npm test -- tests/unit/adapters/authentication.spec.js tests/unit/views/authentication/LoginView.spec.js tests/unit/router/index.spec.js`
- [x] `cd api && npm test -- tests/identities-access-management/acceptance/authentication-routes.test.js` (not run locally: env dependency issue)