### PR TITLE
feat: create journey and found_journeys tables

### DIFF
--- a/api/db/migrations/20260422101500_create-passenger-journeys.js
+++ b/api/db/migrations/20260422101500_create-passenger-journeys.js
@@ -1,0 +1,55 @@
+/**
+ * @param { import("knex").Knex } knex - The Knex instance
+ * @returns { Promise<void> }
+ */
+async function up(knex) {
+  await knex.schema.createTable("passenger_journeys", (table) => {
+    table.increments("id").primary();
+    table
+      .integer("userId")
+      .notNullable()
+      .references("id")
+      .inTable("users")
+      .onDelete("CASCADE");
+    table.timestamp("departure_time").notNullable().comment("departure time");
+    table.timestamp("arrival_time").notNullable().comment("arrival time");
+    table.text("departure_address").notNullable();
+    table.text("arrival_address").notNullable();
+    table
+      .decimal("departure_lon", 11, 8)
+      .notNullable()
+      .comment(
+        "departure longitude is a parameter for the algorythm to find the closest passenger",
+      );
+    table
+      .decimal("departure_lat", 10, 8)
+      .notNullable()
+      .comment(
+        "departure latitude is a parameter for the algorythm to find the closest passenger",
+      );
+    table
+      .decimal("arrival_lon", 11, 8)
+      .notNullable()
+      .comment(
+        "arrival longitude is a parameter for the algorythm to find the closest passenger",
+      );
+    table
+      .decimal("arrival_lat", 10, 8)
+      .notNullable()
+      .comment(
+        "arrival latitude is a parameter for the algorythm to find the closest passenger",
+      );
+    table.timestamp("created_at").defaultTo(knex.fn.now());
+    table.timestamp("updated_at").defaultTo(knex.fn.now());
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex - The Knex instance
+ * @returns { Promise<void> }
+ */
+async function down(knex) {
+  await knex.schema.dropTable("passenger_journeys");
+}
+
+export { down, up };

--- a/api/db/migrations/20260422101500_create-passenger-journeys.js
+++ b/api/db/migrations/20260422101500_create-passenger-journeys.js
@@ -39,8 +39,8 @@ async function up(knex) {
       .comment(
         "arrival latitude is a parameter for the algorythm to find the closest passenger",
       );
-    table.timestamp("createdAt").defaultTo(knex.fn.now());
-    table.timestamp("updatedAt").defaultTo(knex.fn.now());
+    table.timestamp("created_at").defaultTo(knex.fn.now());
+    table.timestamp("updated_at").defaultTo(knex.fn.now());
   });
 }
 

--- a/api/db/migrations/20260422101500_create-passenger-journeys.js
+++ b/api/db/migrations/20260422101500_create-passenger-journeys.js
@@ -11,36 +11,36 @@ async function up(knex) {
       .references("id")
       .inTable("users")
       .onDelete("CASCADE");
-    table.timestamp("departure_time").notNullable().comment("departure time");
-    table.timestamp("arrival_time").notNullable().comment("arrival time");
-    table.text("departure_address").notNullable();
-    table.text("arrival_address").notNullable();
+    table.timestamp("departureTime").notNullable().comment("departure time");
+    table.timestamp("arrivalTime").notNullable().comment("arrival time");
+    table.text("departureAddress").notNullable();
+    table.text("arrivalAddress").notNullable();
     table
-      .decimal("departure_lon", 11, 8)
+      .decimal("departureLon", 11, 8)
       .notNullable()
       .comment(
         "departure longitude is a parameter for the algorythm to find the closest passenger",
       );
     table
-      .decimal("departure_lat", 10, 8)
+      .decimal("departureLat", 10, 8)
       .notNullable()
       .comment(
         "departure latitude is a parameter for the algorythm to find the closest passenger",
       );
     table
-      .decimal("arrival_lon", 11, 8)
+      .decimal("arrivalLon", 11, 8)
       .notNullable()
       .comment(
         "arrival longitude is a parameter for the algorythm to find the closest passenger",
       );
     table
-      .decimal("arrival_lat", 10, 8)
+      .decimal("arrivalLat", 10, 8)
       .notNullable()
       .comment(
         "arrival latitude is a parameter for the algorythm to find the closest passenger",
       );
-    table.timestamp("created_at").defaultTo(knex.fn.now());
-    table.timestamp("updated_at").defaultTo(knex.fn.now());
+    table.timestamp("createdAt").defaultTo(knex.fn.now());
+    table.timestamp("updatedAt").defaultTo(knex.fn.now());
   });
 }
 

--- a/api/db/migrations/20260422101510_create-companion-journeys.js
+++ b/api/db/migrations/20260422101510_create-companion-journeys.js
@@ -39,8 +39,8 @@ async function up(knex) {
       .comment(
         "arrival latitude is a parameter for the algorythm to find the closest passenger",
       );
-    table.timestamp("createdAt").defaultTo(knex.fn.now());
-    table.timestamp("updatedAt").defaultTo(knex.fn.now());
+    table.timestamp("created_at").defaultTo(knex.fn.now());
+    table.timestamp("updated_at").defaultTo(knex.fn.now());
   });
 }
 

--- a/api/db/migrations/20260422101510_create-companion-journeys.js
+++ b/api/db/migrations/20260422101510_create-companion-journeys.js
@@ -11,36 +11,36 @@ async function up(knex) {
       .references("id")
       .inTable("users")
       .onDelete("CASCADE");
-    table.timestamp("departure_time").notNullable().comment("departure time");
-    table.timestamp("arrival_time").notNullable().comment("arrival time");
-    table.text("departure_address").notNullable();
-    table.text("arrival_address").notNullable();
+    table.timestamp("departureTime").notNullable().comment("departure time");
+    table.timestamp("arrivalTime").notNullable().comment("arrival time");
+    table.text("departureAddress").notNullable();
+    table.text("arrivalAddress").notNullable();
     table
-      .decimal("departure_lon", 11, 8)
+      .decimal("departureLon", 11, 8)
       .notNullable()
       .comment(
         "departure longitude is a parameter for the algorythm to find the closest passenger",
       );
     table
-      .decimal("departure_lat", 10, 8)
+      .decimal("departureLat", 10, 8)
       .notNullable()
       .comment(
         "departure latitude is a parameter for the algorythm to find the closest passenger",
       );
     table
-      .decimal("arrival_lon", 11, 8)
+      .decimal("arrivalLon", 11, 8)
       .notNullable()
       .comment(
         "arrival longitude is a parameter for the algorythm to find the closest passenger",
       );
     table
-      .decimal("arrival_lat", 10, 8)
+      .decimal("arrivalLat", 10, 8)
       .notNullable()
       .comment(
         "arrival latitude is a parameter for the algorythm to find the closest passenger",
       );
-    table.timestamp("created_at").defaultTo(knex.fn.now());
-    table.timestamp("updated_at").defaultTo(knex.fn.now());
+    table.timestamp("createdAt").defaultTo(knex.fn.now());
+    table.timestamp("updatedAt").defaultTo(knex.fn.now());
   });
 }
 

--- a/api/db/migrations/20260422101510_create-companion-journeys.js
+++ b/api/db/migrations/20260422101510_create-companion-journeys.js
@@ -1,0 +1,55 @@
+/**
+ * @param { import("knex").Knex } knex - The Knex instance
+ * @returns { Promise<void> }
+ */
+async function up(knex) {
+  await knex.schema.createTable("companion_journeys", (table) => {
+    table.increments("id").primary();
+    table
+      .integer("userId")
+      .notNullable()
+      .references("id")
+      .inTable("users")
+      .onDelete("CASCADE");
+    table.timestamp("departure_time").notNullable().comment("departure time");
+    table.timestamp("arrival_time").notNullable().comment("arrival time");
+    table.text("departure_address").notNullable();
+    table.text("arrival_address").notNullable();
+    table
+      .decimal("departure_lon", 11, 8)
+      .notNullable()
+      .comment(
+        "departure longitude is a parameter for the algorythm to find the closest passenger",
+      );
+    table
+      .decimal("departure_lat", 10, 8)
+      .notNullable()
+      .comment(
+        "departure latitude is a parameter for the algorythm to find the closest passenger",
+      );
+    table
+      .decimal("arrival_lon", 11, 8)
+      .notNullable()
+      .comment(
+        "arrival longitude is a parameter for the algorythm to find the closest passenger",
+      );
+    table
+      .decimal("arrival_lat", 10, 8)
+      .notNullable()
+      .comment(
+        "arrival latitude is a parameter for the algorythm to find the closest passenger",
+      );
+    table.timestamp("created_at").defaultTo(knex.fn.now());
+    table.timestamp("updated_at").defaultTo(knex.fn.now());
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex - The Knex instance
+ * @returns { Promise<void> }
+ */
+async function down(knex) {
+  await knex.schema.dropTable("companion_journeys");
+}
+
+export { down, up };

--- a/api/db/migrations/20260422101520_create-found-journeys.js
+++ b/api/db/migrations/20260422101520_create-found-journeys.js
@@ -1,3 +1,5 @@
+import { JOURNEY_STATUS } from "../../src/shared/constants.js";
+
 /**
  * @param { import("knex").Knex } knex - The Knex instance
  * @returns { Promise<void> }
@@ -17,9 +19,9 @@ async function up(knex) {
       .references("id")
       .inTable("passenger_journeys")
       .onDelete("CASCADE");
-    table.string("status").notNullable().defaultTo("waiting");
-    table.timestamp("created-at").defaultTo(knex.fn.now());
-    table.timestamp("updated-at").defaultTo(knex.fn.now());
+    table.string("status").notNullable().defaultTo(JOURNEY_STATUS.WAITING);
+    table.timestamp("created_at").defaultTo(knex.fn.now());
+    table.timestamp("updated_at").defaultTo(knex.fn.now());
   });
 }
 

--- a/api/db/migrations/20260422101520_create-found-journeys.js
+++ b/api/db/migrations/20260422101520_create-found-journeys.js
@@ -6,20 +6,20 @@ async function up(knex) {
   await knex.schema.createTable("found_journeys", (table) => {
     table.increments("id").primary();
     table
-      .integer("companion_journey_id")
+      .integer("companionJourneyId")
       .notNullable()
       .references("id")
       .inTable("companion_journeys")
       .onDelete("CASCADE");
     table
-      .integer("passenger_journey_id")
+      .integer("passengerJourneyId")
       .notNullable()
       .references("id")
       .inTable("passenger_journeys")
       .onDelete("CASCADE");
     table.string("status").notNullable().defaultTo("waiting");
-    table.timestamp("created_at").defaultTo(knex.fn.now());
-    table.timestamp("updated_at").defaultTo(knex.fn.now());
+    table.timestamp("createdAt").defaultTo(knex.fn.now());
+    table.timestamp("updatedAt").defaultTo(knex.fn.now());
   });
 }
 

--- a/api/db/migrations/20260422101520_create-found-journeys.js
+++ b/api/db/migrations/20260422101520_create-found-journeys.js
@@ -18,8 +18,8 @@ async function up(knex) {
       .inTable("passenger_journeys")
       .onDelete("CASCADE");
     table.string("status").notNullable().defaultTo("waiting");
-    table.timestamp("createdAt").defaultTo(knex.fn.now());
-    table.timestamp("updatedAt").defaultTo(knex.fn.now());
+    table.timestamp("created-at").defaultTo(knex.fn.now());
+    table.timestamp("updated-at").defaultTo(knex.fn.now());
   });
 }
 

--- a/api/db/migrations/20260422101520_create-found-journeys.js
+++ b/api/db/migrations/20260422101520_create-found-journeys.js
@@ -1,0 +1,34 @@
+/**
+ * @param { import("knex").Knex } knex - The Knex instance
+ * @returns { Promise<void> }
+ */
+async function up(knex) {
+  await knex.schema.createTable("found_journeys", (table) => {
+    table.increments("id").primary();
+    table
+      .integer("companion_journey_id")
+      .notNullable()
+      .references("id")
+      .inTable("companion_journeys")
+      .onDelete("CASCADE");
+    table
+      .integer("passenger_journey_id")
+      .notNullable()
+      .references("id")
+      .inTable("passenger_journeys")
+      .onDelete("CASCADE");
+    table.string("status").notNullable().defaultTo("waiting");
+    table.timestamp("created_at").defaultTo(knex.fn.now());
+    table.timestamp("updated_at").defaultTo(knex.fn.now());
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex - The Knex instance
+ * @returns { Promise<void> }
+ */
+async function down(knex) {
+  await knex.schema.dropTable("found_journeys");
+}
+
+export { down, up };

--- a/api/src/shared/constants.js
+++ b/api/src/shared/constants.js
@@ -16,3 +16,20 @@ export const USER_TYPES = {
  * Default user type for new registrations
  */
 export const DEFAULT_USER_TYPE = USER_TYPES.USER;
+/**
+ * Journey status constants
+ * @readonly
+ * @enum {string}
+ */
+export const JOURNEY_STATUS = {
+  /** Waiting for confirmation */
+  WAITING: "waiting",
+  /** Journey accepted by both parties */
+  ACCEPTED: "accepted",
+  /** Journey rejected */
+  REJECTED: "rejected",
+  /** Journey cancelled */
+  CANCELLED: "cancelled",
+  /** Journey successfully completed */
+  COMPLETED: "completed",
+};


### PR DESCRIPTION
This pull request introduces a new migration script to support journey tracking features in the database. The migration creates three new tables to store passenger journeys, companion journeys, and the relationships between them.

**Database schema changes:**

* Added `passenger_journeys` table to store journey details for passengers, including user reference, addresses, coordinates, and timestamps.
* Added `companion_journeys` table to store journey details for companions, with similar structure to `passenger_journeys`.
* Added `found_journeys` table to link companion and passenger journeys, track their matching status, and manage their relationships.
* Provided corresponding `down` migration to drop all three tables if needed.