### PR TITLE
tech: Add some columns to users table and complete seeds

### DIFF
--- a/api/db/database-builder/factory/build-user.js
+++ b/api/db/database-builder/factory/build-user.js
@@ -1,7 +1,7 @@
 import { generatePassword } from "../../../src/identities-access-management/services/password-service.js";
 import { DEFAULT_USER_TYPE } from "../../../src/shared/constants.js";
 import { knex } from "../../knex-database-connection.js";
-async function buildUser({ firstname = "John", lastname = "Doe", email = "john.doe@example.net", birthday = "01/01/1970", created_at = new Date(), updated_at = new Date(), isActive = true, isChecked = true, hashedPassword = null, userType = DEFAULT_USER_TYPE, lastLoggedAt = null } = {}) {
+async function buildUser({ firstname = "John", lastname = "Doe", email = "john.doe@example.net", birthday = "01/01/1970", created_at = new Date(), updated_at = new Date(), isActive = true, isChecked = true, hashedPassword = null, userType = DEFAULT_USER_TYPE, lastLoggedAt = null, role = null, genre = null, disabilities = null } = {}) {
   if (!hashedPassword) {
     hashedPassword = await generatePassword("password");
   }
@@ -17,6 +17,9 @@ async function buildUser({ firstname = "John", lastname = "Doe", email = "john.d
     hashedPassword,
     userType,
     lastLoggedAt,
+    genre,
+    disabilities,
+    role,
   }).returning("*");
   return values;
 }

--- a/api/db/migrations/20260421141308_add-columns-to-users-table.js
+++ b/api/db/migrations/20260421141308_add-columns-to-users-table.js
@@ -1,0 +1,25 @@
+const TABLE_NAME = "users";
+const COLUMNS = ["genre", "role"];
+
+/**
+ * @param { import("knex").Knex } knex - The Knex instance
+ * @returns { Promise<void> }
+ */
+async function up(knex) {
+  await knex.schema.alterTable(TABLE_NAME, (table) => {
+    COLUMNS.map((column) => table.string(column).defaultTo(null));
+    table.specificType("disabilities", "text[]");
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex - The Knex instance
+ * @returns { Promise<void> }
+ */
+async function down(knex) {
+  await knex.schema.alterTable(TABLE_NAME, (table) => {
+    COLUMNS.map((column) => table.dropColumn(column));
+  });
+};
+
+export { down, up };

--- a/api/db/seeds/data/users.js
+++ b/api/db/seeds/data/users.js
@@ -1,20 +1,30 @@
 import { generatePassword } from "../../../src/identities-access-management/services/password-service.js";
-import { DEFAULT_USER_TYPE } from "../../../src/shared/constants.js";
-
-const password = await generatePassword("kompagnon123");
+import { USER_DISABILITIES, USER_ROLE } from "../../../src/shared/constants.js";
 async function users(databaseBuilder) {
-  const simpleUser = {
-    firstname: "simple",
-    lastname: "user",
-    email: "simple.user@example.net",
-    birthday: "01/01/1970",
-    hashedPassword: password,
-    userType: DEFAULT_USER_TYPE,
-    lastLoggedAt: new Date("2025-10-08"),
-  };
+  const hashedPassword = await generatePassword("kompagnon123");
+  const users = [
+    // User valid, compagnon
+    {
+      firstname: "Albert",
+      lastname: "Berlat",
+      email: "albert.berlat@example.net",
+      role: USER_ROLE.VALID,
+      hashedPassword,
+    },
+    // Invalid user with blind disability
+    {
+      firstname: "Andrea",
+      lastname: "Marceti",
+      email: "a.marceti@examle.net",
+      role: USER_ROLE.INVALID,
+      disabilities: USER_DISABILITIES.BLIND,
+      hashedPassword,
+    },
+    // Add other users here
+  ];
 
   // call database builder with data
-  await databaseBuilder.factory.buildUser(simpleUser);
+  await Promise.all(users.map((user) => databaseBuilder.factory.buildUser(user)));
 }
 
 export { users };

--- a/api/src/shared/constants.js
+++ b/api/src/shared/constants.js
@@ -16,6 +16,7 @@ export const USER_TYPES = {
  * Default user type for new registrations
  */
 export const DEFAULT_USER_TYPE = USER_TYPES.USER;
+
 /**
  * Journey status constants
  * @readonly
@@ -32,4 +33,32 @@ export const JOURNEY_STATUS = {
   CANCELLED: "cancelled",
   /** Journey successfully completed */
   COMPLETED: "completed",
+};
+
+/**
+ * User genres
+ */
+export const USER_GENRES = {
+  M: "M",
+  F: "F",
+};
+
+/**
+ * User status
+ * invalid / valid
+ */
+export const USER_ROLE = {
+  VALID: "valid",
+  INVALID: "invalid",
+};
+
+/**
+ * Disability type
+ * Only for give a simple feedback without details
+ */
+export const USER_DISABILITIES = {
+  BLIND: "blind",
+  VISUAL_DIFFICULTIES: "visually",
+  WHEELCHAIR: "wheelchair",
+  MENTAL: "mental",
 };


### PR DESCRIPTION
This pull request introduces new user attributes to the database and related code, specifically adding support for user genre, role, and disabilities. The changes include a database migration, updates to the user factory and seeds, and new constants for these attributes.

**Database schema changes:**

* Added new columns `genre`, `role`, and `disabilities` (all nullable strings) to the `users` table via a migration (`20260421141308_add-columns-to-users-table.js`).

**User data handling and seeding:**

* Updated the `buildUser` factory function to accept and store the new fields: `genre`, `role`, and `disabilities` (`build-user.js`). [[1]](diffhunk://#diff-6a4203bd68fe617c36fcea843c65e1e99e598420b456c370b303cb6d6324bd67L4-R4) [[2]](diffhunk://#diff-6a4203bd68fe617c36fcea843c65e1e99e598420b456c370b303cb6d6324bd67R20-R22)
* Modified the user seed data to include the new `role` and `disability` fields, and to use the new constants (`users.js`).

**Constants and shared definitions:**

* Introduced new constants for user genres, roles, and disabilities in `constants.js`, making these values standardized and easy to reference throughout the codebase.