### PR TITLE
tech: Use api to serve front and prepare deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 
 # IDE
 .idea
+
+# dists in api
+**/dists/**

--- a/admin/src/components/PasswordComponent.vue
+++ b/admin/src/components/PasswordComponent.vue
@@ -34,14 +34,14 @@ function updateValue(event) {
         :id="`password-${label}`"
         :type="inputType"
         :value="modelValue"
-        @input="updateValue"
         class="password-input"
-      />
+        @input="updateValue"
+      >
       <button
         type="button"
-        @click="togglePasswordVisibility"
         class="toggle-button"
         :aria-label="showPassword ? 'Masquer le mot de passe' : 'Afficher le mot de passe'"
+        @click="togglePasswordVisibility"
       >
         {{ showPassword ? "👁️" : "👁️‍🗨️" }}
       </button>

--- a/admin/vite.config.js
+++ b/admin/vite.config.js
@@ -5,13 +5,17 @@ import { defineConfig, loadEnv } from "vite";
 import vueDevTools from "vite-plugin-vue-devtools";
 
 // https://vite.dev/config/
-export default defineConfig(function({ mode }) {
+export default defineConfig(function({ command, mode }) {
   const env = loadEnv(mode, process.cwd());
   const config = {
     plugins: [
       vue(),
       vueDevTools(),
     ],
+    build: {
+      outDir: "../api/dists/admin",
+      emptyOutDir: true,
+    },
     resolve: {
       alias: {
         "@": fileURLToPath(new URL("./src", import.meta.url)),
@@ -19,12 +23,16 @@ export default defineConfig(function({ mode }) {
     },
     server: {
       open: true,
-      proxy: {
-        "/api": {
-          target: env.VITE_API_URL,
-        },
-      },
     },
   };
+  if (mode === "production") {
+    config.base = "/admin";
+  } else if (command === "serve") {
+    config.server.proxy = {
+      "/api": {
+        target: env.VITE_API_URL,
+      },
+    };
+  }
   return config;
 });

--- a/api/eslint.config.js
+++ b/api/eslint.config.js
@@ -81,6 +81,6 @@ export default defineConfig([
     },
   },
   {
-    ignores: ["./dist/*"],
+    ignores: ["./dists/*"],
   },
 ]);

--- a/api/server.js
+++ b/api/server.js
@@ -4,6 +4,7 @@ import express from "express";
 
 import { logger } from "./logger.js";
 import authenticationRoutes from "./src/identities-access-management/routes/authentication-routes.js";
+import fronts from "./src/shared/fronts/fronts-routes.js";
 import health from "./src/shared/health/routes.js";
 import swaggerRoute from "./swagger.js";
 
@@ -12,13 +13,17 @@ const server = express();
 server.use(cors());
 server.use(express.json());
 server.use(swaggerRoute);
+
+// Log api calls
 server.use((req, res, next) => {
-  res.on("finish", () => {
-    logger.info(`${req.method} ${req.url} ${res.statusCode}`);
-  });
+  if (req.path.startsWith("/api")) {
+    res.on("finish", () => {
+      logger.info(`${req.method} ${req.url} ${res.statusCode}`);
+    });
+  }
   next();
 });
-
+server.use(fronts);
 server.use(health);
 server.use(authenticationRoutes);
 

--- a/api/src/shared/fronts/fronts-routes.js
+++ b/api/src/shared/fronts/fronts-routes.js
@@ -1,0 +1,17 @@
+// Expose fronts
+// Serve static files from the bundled dists directory using a reliable
+// absolute path (works with ES modules).
+import express from "express";
+import path from "path";
+
+const fronts = express.Router();
+fronts.use(
+  "/",
+  express.static(path.join("dists", "web")),
+);
+fronts.use(
+  "/admin",
+  express.static(path.join("dists", "admin")),
+);
+
+export default fronts;

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "test:api": "cd api && npm test",
     "test:web": "cd web && npm test",
     "test:admin": "cd admin && npm test",
-    "test": "run-p --print-label test:api test:web test:admin"
+    "test": "run-p --print-label test:api test:web test:admin",
+    "start": "cd api && npm start"
   },
   "dependencies": {
     "npm-run-all": "^4.1.5"

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -5,13 +5,17 @@ import { defineConfig, loadEnv } from "vite";
 import vueDevTools from "vite-plugin-vue-devtools";
 
 // https://vite.dev/config/
-export default defineConfig(function({ mode }) {
+export default defineConfig(function({ command, mode }) {
   const env = loadEnv(mode, process.cwd());
   const config = {
     plugins: [
       vue(),
       vueDevTools(),
     ],
+    build: {
+      outDir: "../api/dists/web",
+      emptyOutDir: true,
+    },
     resolve: {
       alias: {
         "@": fileURLToPath(new URL("./src", import.meta.url)),
@@ -19,12 +23,16 @@ export default defineConfig(function({ mode }) {
     },
     server: {
       open: true,
-      proxy: {
-        "/api": {
-          target: env.VITE_API_URL,
-        },
-      },
     },
   };
+  if (command === "serve") {
+    config.server.proxy = {
+      "/api": {
+        target: env.VITE_API_URL,
+      },
+    };
+  } else if (mode === "production") {
+    config.base = "/";
+  }
   return config;
 });


### PR DESCRIPTION
## Problem
Actually, we must deploy one app or service by application. It's most expensive to deploy, because we must have one app and project by application.

## Proposition
Configure the project to build the admin and web apps in api specific folder. After, when starting api, webb apps are served by the api. The web app is served on '/' route and the admin app is served on '/admin' route. Applications are configured to keep old system in dev mode.

### Advantage
- Build one only app,
- easy api call,
- No external calls.

### Difficulties
- most logs if errors,
- Important check on security.

### Note
In the biggening of project, we used the api to serve front and this feature has removed after because we didn't think to use specific route. Today, with webHashHistory of vue-js, we can customize the api routes to going to fronts.

## Tests
This test must realized with web and admin apps.
- Build the admin app,
- Start the api,
- Goto localhost:3000/admin,
- Check that the page is displayed,
- Start the admin app with npm run dev, on admin folder,
- Goto localhost:5173,
- Check that admin is displayed.