### PR TITLE
tech: Add a workflow to merge main in production branch

### DIFF
--- a/.github/workflows/PR Title Check.yml
+++ b/.github/workflows/PR Title Check.yml
@@ -2,13 +2,14 @@ name: PR Title Check
 
 on:
   pull_request:
-    types: [opened, reopened, edited, synchronize]
+    types: [opened, reopened, edited, synchronize, ready_for_review]
     branches:
       - main
   merge_group:
 
 jobs:
   check-title:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/merge-into-production.yml
+++ b/.github/workflows/merge-into-production.yml
@@ -1,0 +1,31 @@
+name: merge into production
+
+on:
+  release:
+    types:
+      - released
+
+permissions:
+  contents: write
+
+jobs:
+  merge-main-into-production:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.SERVICE_TOKEN }}
+          fetch-depth: 0
+
+      - name: Merge main into production
+        run: |
+          git checkout production
+          git merge origin/main --no-edit
+
+      - name: Push changes
+        run: |
+          git push origin production
+        env:
+          GITHUB_TOKEN: ${{ secrets.SERVICE_TOKEN }}

--- a/.github/workflows/merge-into-production.yml
+++ b/.github/workflows/merge-into-production.yml
@@ -19,10 +19,16 @@ jobs:
           token: ${{ secrets.SERVICE_TOKEN }}
           fetch-depth: 0
 
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
       - name: Merge main into production
         run: |
-          git checkout production
-          git merge origin/main --no-edit
+          git fetch origin main production
+          git checkout -B production origin/production
+          git merge --no-edit origin/main
 
       - name: Push changes
         run: |

--- a/.github/workflows/merge-into-production.yml
+++ b/.github/workflows/merge-into-production.yml
@@ -3,7 +3,7 @@ name: merge into production
 on:
   release:
     types:
-      - released
+      - published
 
 permissions:
   contents: write


### PR DESCRIPTION
This pull request introduces improvements to the GitHub Actions workflows for managing pull requests and automating merges into the production branch. The main changes include enhancing the PR title check workflow to better handle draft PRs and adding a new workflow to automatically merge the `main` branch into `production` upon a release.

**Workflow enhancements:**

* [`.github/workflows/PR Title Check.yml`](diffhunk://#diff-e6d2be8389bd688a7879afcde237f873c599b6d1fe794a6a4352e4a428192e93L5-R12): Updated to trigger on the `ready_for_review` event and to skip title checks for draft pull requests, ensuring checks only run on active PRs.

**Automation for production releases:**

* [`.github/workflows/merge-into-production.yml`](diffhunk://#diff-c7ddf0cf819f39b18b03267dcda72c2e8b4dd330d06538d6963975e85c8e41d0R1-R31): Added a new workflow that automatically merges the latest changes from `main` into `production` whenever a release is published, streamlining the deployment process.