### PR TITLE
fix: Fix the empty database script and deployment script

### DIFF
--- a/api/db/empty-database.js
+++ b/api/db/empty-database.js
@@ -1,7 +1,7 @@
 import process from "node:process";
 
 import { logger } from "../logger.js";
-import { disconnect, emptyAllTablesOfDatabase } from "./knex-database-connections.js";
+import { disconnect, emptyAllTablesOfDatabase } from "./knex-database-connection.js";
 
 async function main() {
   logger.info("Emptying all tables...");

--- a/api/db/knex-database-connection.js
+++ b/api/db/knex-database-connection.js
@@ -59,7 +59,6 @@ async function emptyAllTablesOfDatabase() {
     tableNames,
     "knex_migrations",
     "knex_migrations_lock",
-    "view-active-organization-learners",
   );
 
   const tables = _.map(tablesToDelete, (tableToDelete) => `"${tableToDelete}"`).join();

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -13,5 +13,8 @@ npm --prefix api ci
 echo "Running migrations..."
 npm --prefix api run db:migrate
 
+# Empty the database before seeding
+npm --prefix api run db:empty
+
 # seed database for testing
 npm --prefix api run db:seed


### PR DESCRIPTION
This pull request makes a small but important fix to the database utilities and deployment script. The main change is correcting an import statement in `empty-database.js` to use the correct file name, and updating the deployment script to empty the database before seeding.

**Database utility fix:**

* Fixed a typo in the import path in `empty-database.js` to use `knex-database-connection.js` instead of the incorrect plural form.

**Deployment process improvement:**

* Updated `deploy.sh` to run the database emptying script before seeding, ensuring a clean state for test data.