### PR TITLE
feat: Implemente route to record a new journey

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -5,6 +5,7 @@ import express from "express";
 import { logger } from "./logger.js";
 import authenticationRoutes from "./src/identities-access-management/routes/authentication-routes.js";
 import usersRoutes from "./src/identities-access-management/routes/users-routes.js";
+import journeysRoutes from "./src/journeys/api/routes/journeys-routes.js";
 import fronts from "./src/shared/fronts/fronts-routes.js";
 import health from "./src/shared/health/routes.js";
 import swaggerRoute from "./swagger.js";
@@ -28,6 +29,7 @@ server.use(fronts);
 server.use(health);
 server.use(authenticationRoutes);
 server.use(usersRoutes);
+server.use(journeysRoutes);
 
 // do not write routes under this line
 // eslint-disable-next-line no-unused-vars

--- a/api/src/journeys/api/controllers/record-journey-controller.js
+++ b/api/src/journeys/api/controllers/record-journey-controller.js
@@ -1,0 +1,57 @@
+import { celebrate, Joi, Segments } from "celebrate";
+
+import { logger } from "../../../../logger.js";
+import { findUserById } from "../../../identities-access-management/repositories/user-repository.js";
+import { USER_ROLE } from "../../../shared/constants.js";
+import usecases from "../../usecases/index.js";
+
+const recordJourneyControllerSchema = celebrate({
+  [Segments.BODY]: Joi.object({
+    departureAddress: Joi.string().required(),
+    arrivalAddress: Joi.string().required(),
+    departureLat: Joi.number().min(-90).max(90).required(),
+    departureLon: Joi.number().min(-180).max(180).required(),
+    arrivalLat: Joi.number().min(-90).max(90).required(),
+    arrivalLon: Joi.number().min(-180).max(180).required(),
+    departureTime: Joi.date().required(),
+    arrivalTime: Joi.date().required(),
+  }),
+});
+
+/**
+ * Controller for recording a journey. It checks the user's role and calls the appropriate use case to record the journey.
+ * If the user is invalid, it calls the recordPassengerJourneyUsecase. If the user is valid, it calls the recordCompanionJourneyUsecase.
+ * @param {object} req - The request object, which contains the user's authentication information and the journey details in the body.
+ * @param {object} res - The response object, which is used to send the response back to the client.
+ * @param {Function} next - The next middleware function in the Express.js pipeline, used for error handling.
+ * @param {object} journeyUsecases - An optional parameter for the use cases, which defaults to the imported use cases. This allows for dependency injection during testing.
+ * @param {Function} findUserRepository - An optional parameter for the function to find a user by ID, which defaults to the imported findUserById function. This allows for dependency injection during testing.
+ * @returns {Promise<*>} - A promise that resolves to the response sent back to the client, which can be a success message or an error message depending on the outcome of the operation.
+ */
+async function recordJourneyController(
+  req,
+  res,
+  next,
+  journeyUsecases = usecases,
+  findUserRepository = findUserById) {
+  const { auth, body } = req;
+  try {
+    const user = await findUserRepository(auth.userId);
+    let result;
+    if (user.role === USER_ROLE.INVALID) {
+      result = await journeyUsecases.recordPassengerJourneyUsecase({ userId: user.id, ...body });
+    } else if (user.role === USER_ROLE.VALID) {
+      result = await journeyUsecases.recordCompanionJourneyUsecase({ userId: user.id, ...body });
+    } else {
+      return res.status(400).json({ error: "Invalid user role" });
+    }
+    if (result) {
+      return res.status(201).json({ data: result });
+    }
+  } catch (error) {
+    logger.error(`Error during journey recording, ${error}`);
+    return res.status(500).send();
+  }
+}
+
+export { recordJourneyController, recordJourneyControllerSchema };

--- a/api/src/journeys/api/routes/journeys-routes.js
+++ b/api/src/journeys/api/routes/journeys-routes.js
@@ -1,0 +1,81 @@
+import express from "express";
+
+import { authMiddleware } from "../../../shared/infrastructure/middlewares/auth-middleware.js";
+import { recordJourneyController, recordJourneyControllerSchema } from "../controllers/record-journey-controller.js";
+
+const journeysRoutes = express.Router();
+
+/**
+ * @swagger
+ * /api/journeys:
+ *   post:
+ *     summary: Record a new journey
+ *     description: Records a journey for the authenticated user as a passenger or companion depending on the user role.
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - departureAddress
+ *               - arrivalAddress
+ *               - departureLat
+ *               - departureLon
+ *               - arrivalLat
+ *               - arrivalLon
+ *               - departureTime
+ *               - arrivalTime
+ *             properties:
+ *               departureAddress:
+ *                 type: string
+ *                 example: 10 Rue de Rivoli, Paris
+ *               arrivalAddress:
+ *                 type: string
+ *                 example: 5 Avenue Anatole France, Paris
+ *               departureLat:
+ *                 type: number
+ *                 example: 48.8566
+ *               departureLon:
+ *                 type: number
+ *                 example: 2.3522
+ *               arrivalLat:
+ *                 type: number
+ *                 example: 48.8584
+ *               arrivalLon:
+ *                 type: number
+ *                 example: 2.2945
+ *               departureTime:
+ *                 type: string
+ *                 format: date-time
+ *                 example: 2026-05-16T08:30:00.000Z
+ *               arrivalTime:
+ *                 type: string
+ *                 format: date-time
+ *                 example: 2026-05-16T09:00:00.000Z
+ *     responses:
+ *       201:
+ *         description: Journey recorded successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *               data :
+ *                 type: object
+ *                 properties:
+ *                   journeyId:
+ *                     type: string
+ *                     example: 123e4567-e89b-12d3-a456-426614174000
+ *       400:
+ *         description: Invalid user role or invalid request body
+ *       401:
+ *         description: Unauthorized
+ *       500:
+ *         description: Internal server error
+ */
+journeysRoutes.post("/api/journeys", authMiddleware, recordJourneyControllerSchema, recordJourneyController);
+
+export default journeysRoutes;

--- a/api/src/journeys/repositories/build-journeys-repository.js
+++ b/api/src/journeys/repositories/build-journeys-repository.js
@@ -1,0 +1,65 @@
+import { knex } from "../../../db/knex-database-connection.js";
+
+function buildJourneysRepository(tableName) {
+  /**
+   * Saves a journey.
+   * @param {object} params - Journey details
+   * @param {number} params.userId - ID of the user associated with the journey
+   * @param {string} params.departureTime - Departure time of the journey
+   * @param {string} params.arrivalTime - Arrival time of the journey
+   * @param {string} params.departureAddress - Departure address of the journey
+   * @param {string} params.arrivalAddress - Arrival address of the journey
+   * @param {number} params.departureLon - Longitude of the departure location (optional)
+   * @param {number} params.departureLat - Latitude of the departure location (optional)
+   * @param {number} params.arrivalLon - Longitude of the arrival location (optional)
+   * @param {number} params.arrivalLat - Latitude of the arrival location (optional)
+   * @returns {Promise<*>} - The ID of the saved journey
+   */
+  async function saveJourney({ userId, departureTime, arrivalTime, departureAddress, arrivalAddress, departureLon = null, departureLat = null, arrivalLon = null, arrivalLat = null }) {
+    const [{ id }] = await knex(tableName).insert({
+      userId,
+      departureTime,
+      arrivalTime,
+      departureAddress,
+      arrivalAddress,
+      departureLon,
+      departureLat,
+      arrivalLon,
+      arrivalLat,
+    }).returning("id");
+    return id;
+  }
+
+  /**
+   * Finds a journey by its ID.
+   * @param {number} journeyId - ID of the journey to find
+   * @returns {Promise<*>} - The journey record if found, otherwise null
+   */
+  async function findJourneyById(journeyId) {
+    const journey = await knex(tableName).where({ id: journeyId }).first();
+    return journey || null;
+  }
+
+  /**
+   * Finds all journeys associated with a specific user ID.
+   * @param {number} userId - ID of the user whose journeys to find
+   * @returns {Promise<*>} - An array of journey records associated with the user ID
+   */
+  async function findJourneysByUserId(userId) {
+    const journeys = await knex(tableName).where({ userId });
+    return journeys;
+  }
+
+  /**
+   * Removes a journey by its ID.
+   * @param {number} journeyId - ID of the journey to remove
+   * @returns {Promise<*>} - The number of records deleted (should be 1 if successful, 0 if no record found)
+   */
+  async function removeJourneyByJourneyId(journeyId) {
+    return await knex(tableName).where({ id: journeyId }).del();
+  }
+
+  return { findJourneyById, findJourneysByUserId, removeJourneyByJourneyId, saveJourney };
+}
+
+export { buildJourneysRepository };

--- a/api/src/journeys/repositories/companion-users-repository.js
+++ b/api/src/journeys/repositories/companion-users-repository.js
@@ -1,0 +1,6 @@
+import { buildJourneysRepository } from "./build-journeys-repository.js";
+
+const TABLE_NAME = "companion_journeys";
+const { findJourneyById, findJourneysByUserId, removeJourneyByJourneyId, saveJourney } = buildJourneysRepository(TABLE_NAME);
+
+export { findJourneyById, findJourneysByUserId, removeJourneyByJourneyId, saveJourney };

--- a/api/src/journeys/repositories/passenger-users-repository.js
+++ b/api/src/journeys/repositories/passenger-users-repository.js
@@ -1,0 +1,6 @@
+import { buildJourneysRepository } from "./build-journeys-repository.js";
+
+const TABLE_NAME = "passenger_journeys";
+const { findJourneyById, findJourneysByUserId, removeJourneyByJourneyId, saveJourney } = buildJourneysRepository(TABLE_NAME);
+
+export { findJourneyById, findJourneysByUserId, removeJourneyByJourneyId, saveJourney };

--- a/api/src/journeys/usecases/index.js
+++ b/api/src/journeys/usecases/index.js
@@ -1,0 +1,9 @@
+import { recordCompanionJourneyUsecase } from "./record-companion-journey-usecase.js";
+import { recordPassengerJourneyUsecase } from "./record-passenger-journey-usecase.js";
+
+const usecases = {
+  recordCompanionJourneyUsecase,
+  recordPassengerJourneyUsecase,
+};
+
+export default usecases;

--- a/api/src/journeys/usecases/record-companion-journey-usecase.js
+++ b/api/src/journeys/usecases/record-companion-journey-usecase.js
@@ -1,0 +1,8 @@
+import { saveJourney } from "../repositories/companion-users-repository.js";
+import { recordJourneyUsecase } from "./record-journey-usecase.js";
+
+async function recordCompanionJourneyUsecase({ userId, departureTime, arrivalTime, departureAddress, arrivalAddress, departureLon = null, departureLat = null, arrivalLon = null, arrivalLat = null }) {
+  return await recordJourneyUsecase(saveJourney, { userId, departureTime, arrivalTime, departureAddress, arrivalAddress, departureLon, departureLat, arrivalLon, arrivalLat });
+}
+
+export { recordCompanionJourneyUsecase };

--- a/api/src/journeys/usecases/record-journey-usecase.js
+++ b/api/src/journeys/usecases/record-journey-usecase.js
@@ -1,0 +1,6 @@
+async function recordJourneyUsecase(saveJourneyRepository, journeyData) {
+  const recordedJourneyId = await saveJourneyRepository(journeyData);
+  return { journeyId: recordedJourneyId };
+}
+
+export { recordJourneyUsecase };

--- a/api/src/journeys/usecases/record-passenger-journey-usecase.js
+++ b/api/src/journeys/usecases/record-passenger-journey-usecase.js
@@ -1,0 +1,8 @@
+import { saveJourney } from "../repositories/passenger-users-repository.js";
+import { recordJourneyUsecase } from "./record-journey-usecase.js";
+
+async function recordPassengerJourneyUsecase({ userId, departureTime, arrivalTime, departureAddress, arrivalAddress, departureLon = null, departureLat = null, arrivalLon = null, arrivalLat = null }) {
+  return await recordJourneyUsecase(saveJourney, { userId, departureTime, arrivalTime, departureAddress, arrivalAddress, departureLon, departureLat, arrivalLon, arrivalLat });
+}
+
+export { recordPassengerJourneyUsecase };

--- a/api/tests/helpers/generate-authenticated-user.js
+++ b/api/tests/helpers/generate-authenticated-user.js
@@ -1,0 +1,8 @@
+import { encodedToken } from "../../src/identities-access-management/services/token-service.js";
+
+function generateAuthenticatedUser(userId, userType) {
+  const token = encodedToken({ userId, userType });
+  return `Bearer ${token}`;
+}
+
+export { generateAuthenticatedUser };

--- a/api/tests/journeys/acceptance/journeys-routes.test.js
+++ b/api/tests/journeys/acceptance/journeys-routes.test.js
@@ -1,0 +1,135 @@
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+
+import databaseBuilder from "../../../db/database-builder/index.js";
+import { knex } from "../../../db/knex-database-connection.js";
+import server from "../../../server.js";
+import { USER_ROLE } from "../../../src/shared/constants.js";
+import { generateAuthenticatedUser } from "../../helpers/generate-authenticated-user.js";
+
+describe("Acceptance | Journeys | Journey routes", () => {
+  describe("POST /journeys", () => {
+    describe("invalid user", () => {
+      it("should return 201 http status code", async () => {
+        // given
+        const user = await databaseBuilder.factory.buildUser({ role: USER_ROLE.INVALID });
+        const body = {
+          departureTime: new Date("2024-06-01T10:00:00Z"),
+          arrivalTime: new Date("2024-06-01T11:00:00Z"),
+          departureAddress: "5 avenue des martirs 7502",
+          arrivalAddress: "18 rue Pasteur 75015",
+          departureLat: "0.0",
+          departureLon: "0.0",
+          arrivalLon: "0.0",
+          arrivalLat: "0.0",
+        };
+        const auth = generateAuthenticatedUser(user.id, user.userType);
+
+        // when
+        const response = await request(server).post("/api/journeys").send(body).set("Authorization", auth);
+
+        // then
+        expect(response.status).toBe(201);
+        const recordedJourney = await knex("passenger_journeys").where({ id: response.body.data.journeyId }).first();
+        expect(recordedJourney).toBeDefined();
+      });
+    });
+
+    describe("valid user", () => {
+      it("should return 201 http status code", async () => {
+        // given
+        const user = await databaseBuilder.factory.buildUser({ role: USER_ROLE.VALID });
+        const body = {
+          departureTime: new Date("2024-06-01T10:00:00Z"),
+          arrivalTime: new Date("2024-06-01T11:00:00Z"),
+          departureAddress: "5 avenue des martirs 7502",
+          arrivalAddress: "18 rue Pasteur 75015",
+          departureLat: "0.0",
+          departureLon: "0.0",
+          arrivalLon: "0.0",
+          arrivalLat: "0.0",
+        };
+        const auth = generateAuthenticatedUser(user.id, user.userType);
+
+        // when
+        const response = await request(server).post("/api/journeys").send(body).set("Authorization", auth);
+
+        // then
+        expect(response.status).toBe(201);
+        const recordedJourney = await knex("companion_journeys").where({ id: response.body.data.journeyId }).first();
+        expect(recordedJourney).toBeDefined();
+      });
+    });
+
+    describe("user without role", () => {
+      it("should return 400 http status code", async () => {
+        // given
+        const user = await databaseBuilder.factory.buildUser();
+        const body = {
+          departureTime: new Date("2024-06-01T10:00:00Z"),
+          arrivalTime: new Date("2024-06-01T11:00:00Z"),
+          departureAddress: "5 avenue des martirs 7502",
+          arrivalAddress: "18 rue Pasteur 75015",
+          departureLat: "0.0",
+          departureLon: "0.0",
+          arrivalLon: "0.0",
+          arrivalLat: "0.0",
+        };
+        const auth = generateAuthenticatedUser(user.id, user.userType);
+
+        // when
+        const response = await request(server).post("/api/journeys").send(body).set("Authorization", auth);
+
+        // then
+        expect(response.status).toBe(400);
+      });
+    });
+
+    describe("body check", () => {
+      it("should return 400 http status code if one body field is not present", async () => {
+        // given
+        const user = await databaseBuilder.factory.buildUser({ role: USER_ROLE.INVALID });
+        const body = {
+          departureTime: new Date("2024-06-01T10:00:00Z"),
+          arrivalTime: new Date("2024-06-01T11:00:00Z"),
+          departureAddress: "5 avenue des martirs 7502",
+          arrivalAddress: "18 rue Pasteur 75015",
+          departureLat: "0.0",
+          departureLon: "0.0",
+          arrivalLon: "0.0",
+        };
+        const auth = generateAuthenticatedUser(user.id, user.userType);
+
+        // when
+        const response = await request(server).post("/api/journeys").send(body).set("Authorization", auth);
+
+        // then
+        expect(response.status).toBe(400);
+        expect(response.body.message).toEqual("Validation failed");
+      });
+
+      it("should return 400 http status code if one body field has an incorrect format", async () => {
+        // given
+        const user = await databaseBuilder.factory.buildUser({ role: USER_ROLE.INVALID });
+        const body = {
+          departureTime: new Date("2024-06-01T10:00:00Z"),
+          arrivalTime: new Date("2024-06-01T11:00:00Z"),
+          departureAddress: "5 avenue des martirs 7502",
+          arrivalAddress: "18 rue Pasteur 75015",
+          departureLat: "not-a-coordinate",
+          departureLon: "0.0",
+          arrivalLon: "0.0",
+          arrivalLat: "0.0",
+        };
+        const auth = generateAuthenticatedUser(user.id, user.userType);
+
+        // when
+        const response = await request(server).post("/api/journeys").send(body).set("Authorization", auth);
+
+        // then
+        expect(response.status).toBe(400);
+        expect(response.body.message).toEqual("Validation failed");
+      });
+    });
+  });
+});

--- a/api/tests/journeys/integration/repositories/companion-users-repository.test.js
+++ b/api/tests/journeys/integration/repositories/companion-users-repository.test.js
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+
+import databaseBuilder from "../../../../db/database-builder/index.js";
+import { knex } from "../../../../db/knex-database-connection.js";
+import * as companionUsersRepository from "../../../../src/journeys/repositories/companion-users-repository.js";
+
+describe("Integration | Journeys | Repositories | Companion users repository", () => {
+  describe("#saveJourney", () => {
+    it("should save a journey and return id", async () => {
+      // given
+      const user = await databaseBuilder.factory.buildUser();
+      const data = {
+        userId: user.id,
+        departureTime: new Date().toISOString(),
+        arrivalTime: new Date(Date.now() + 60 * 60 * 1000).toISOString(), // +1h
+        departureAddress: "10 Downing St, London",
+        arrivalAddress: "221B Baker St, London",
+        departureLon: 0.127758, // example lon/lat
+        departureLat: 51.507351,
+        arrivalLon: 0.157000,
+        arrivalLat: 51.523767,
+      };
+
+      // when
+      const id = await companionUsersRepository.saveJourney(data);
+
+      // then
+      expect(id).toBeDefined();
+      expect(typeof id).toBe("number");
+
+      const saved = await knex("companion_journeys").where({ id }).first();
+      expect(saved).toBeDefined();
+      expect(saved.userId).toBe(user.id);
+      expect(saved.departureAddress).toBe(data.departureAddress);
+      expect(saved.arrivalAddress).toBe(data.arrivalAddress);
+      expect(Number(saved.departureLon)).toBeCloseTo(data.departureLon, 6);
+      expect(Number(saved.departureLat)).toBeCloseTo(data.departureLat, 6);
+      expect(Number(saved.arrivalLon)).toBeCloseTo(data.arrivalLon, 6);
+      expect(Number(saved.arrivalLat)).toBeCloseTo(data.arrivalLat, 6);
+    });
+  });
+
+  describe("#findJourneyById", () => {
+    it("should return the journey when it exists", async () => {
+      // given
+      const user = await databaseBuilder.factory.buildUser();
+      const data = {
+        userId: user.id,
+        departureTime: new Date().toISOString(),
+        arrivalTime: new Date(Date.now() + 30 * 60 * 1000).toISOString(), // +30m
+        departureAddress: "Start A",
+        arrivalAddress: "End A",
+        departureLon: 1.23,
+        departureLat: 4.56,
+        arrivalLon: 7.89,
+        arrivalLat: 0.12,
+      };
+
+      // when
+      const id = await companionUsersRepository.saveJourney(data);
+      const found = await companionUsersRepository.findJourneyById(id);
+
+      // then
+      expect(found).toBeDefined();
+      expect(found.id).toBe(id);
+      expect(found.userId).toBe(user.id);
+      expect(found.departureAddress).toBe(data.departureAddress);
+    });
+
+    it("should return null when journey does not exist", async () => {
+      // given & when
+      const found = await companionUsersRepository.findJourneyById(99999999);
+
+      // then
+      expect(found).toBeNull();
+    });
+  });
+
+  describe("#findJourneysByUserId", () => {
+    it("should return all journeys for a given user", async () => {
+      // given
+      const user = await databaseBuilder.factory.buildUser();
+      const otherUser = await databaseBuilder.factory.buildUser({ email: `other-${Date.now()}@example.net` });
+
+      await databaseBuilder.factory.buildCompanionJourney({
+        userId: user.id,
+        departureTime: new Date().toISOString(),
+        arrivalTime: new Date(Date.now() + 20 * 60 * 1000).toISOString(),
+        departureAddress: "A1",
+        arrivalAddress: "B1",
+        departureLon: 0,
+        departureLat: 0,
+        arrivalLon: 0,
+        arrivalLat: 0,
+      });
+      await databaseBuilder.factory.buildCompanionJourney({
+        userId: user.id,
+        departureTime: new Date().toISOString(),
+        arrivalTime: new Date(Date.now() + 40 * 60 * 1000).toISOString(),
+        departureAddress: "A2",
+        arrivalAddress: "B2",
+        departureLon: 0,
+        departureLat: 0,
+        arrivalLon: 0,
+        arrivalLat: 0,
+      });
+      await databaseBuilder.factory.buildCompanionJourney({
+        userId: otherUser.id,
+        departureTime: new Date().toISOString(),
+        arrivalTime: new Date(Date.now() + 10 * 60 * 1000).toISOString(),
+        departureAddress: "AO",
+        arrivalAddress: "BO",
+        departureLon: 0,
+        departureLat: 0,
+        arrivalLon: 0,
+        arrivalLat: 0,
+      });
+
+      // when
+      const journeys = await companionUsersRepository.findJourneysByUserId(user.id);
+
+      // then
+      expect(Array.isArray(journeys)).toBe(true);
+      expect(journeys.length).toBeGreaterThanOrEqual(2);
+      for (const j of journeys) {
+        expect(j.userId).toBe(user.id);
+      }
+    });
+  });
+
+  describe("#removeJourneyByJourneyId", () => {
+    it("should remove an existing journey and return 1", async () => {
+      // given
+      const user = await databaseBuilder.factory.buildUser();
+      const data = await databaseBuilder.factory.buildCompanionJourney({
+        userId: user.id,
+        departureTime: new Date().toISOString(),
+        arrivalTime: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+        departureAddress: "ToRemove",
+        arrivalAddress: "ToRemoveDest",
+        departureLon: 0,
+        departureLat: 0,
+        arrivalLon: 0,
+        arrivalLat: 0,
+      });
+
+      // when
+      const removed = await companionUsersRepository.removeJourneyByJourneyId(data.id);
+
+      // then
+      expect(removed).toBe(1);
+      const found = await knex("companion_journeys").where({ id: data.id });
+      expect(found).toHaveLength(0);
+    });
+
+    it("should return 0 when removing non-existent journey", async () => {
+      // when
+      const removed = await companionUsersRepository.removeJourneyByJourneyId(99999999);
+
+      // then
+      expect(removed).toBe(0);
+    });
+  });
+});

--- a/api/tests/journeys/integration/repositories/passenger-users-repository.test.js
+++ b/api/tests/journeys/integration/repositories/passenger-users-repository.test.js
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+
+import databaseBuilder from "../../../../db/database-builder/index.js";
+import { knex } from "../../../../db/knex-database-connection.js";
+import * as passengerUsersRepository from "../../../../src/journeys/repositories/passenger-users-repository.js";
+
+describe("Integration | Journeys | Repositories | Passenger users repository", () => {
+  describe("#saveJourney", () => {
+    it("should save a journey and return id", async () => {
+      // given
+      const user = await databaseBuilder.factory.buildUser();
+      const data = {
+        userId: user.id,
+        departureTime: new Date().toISOString(),
+        arrivalTime: new Date(Date.now() + 60 * 60 * 1000).toISOString(), // +1h
+        departureAddress: "10 Downing St, London",
+        arrivalAddress: "221B Baker St, London",
+        departureLon: 0.127758, // example lon/lat
+        departureLat: 51.507351,
+        arrivalLon: 0.157000,
+        arrivalLat: 51.523767,
+      };
+
+      // when
+      const id = await passengerUsersRepository.saveJourney(data);
+
+      // then
+      expect(id).toBeDefined();
+      expect(typeof id).toBe("number");
+
+      const saved = await knex("passenger_journeys").where({ id }).first();
+      expect(saved).toBeDefined();
+      expect(saved.userId).toBe(user.id);
+      expect(saved.departureAddress).toBe(data.departureAddress);
+      expect(saved.arrivalAddress).toBe(data.arrivalAddress);
+      expect(Number(saved.departureLon)).toBeCloseTo(data.departureLon, 6);
+      expect(Number(saved.departureLat)).toBeCloseTo(data.departureLat, 6);
+      expect(Number(saved.arrivalLon)).toBeCloseTo(data.arrivalLon, 6);
+      expect(Number(saved.arrivalLat)).toBeCloseTo(data.arrivalLat, 6);
+    });
+  });
+
+  describe("#findJourneyById", () => {
+    it("should return the journey when it exists", async () => {
+      // given
+      const user = await databaseBuilder.factory.buildUser();
+      const data = {
+        userId: user.id,
+        departureTime: new Date().toISOString(),
+        arrivalTime: new Date(Date.now() + 30 * 60 * 1000).toISOString(), // +30m
+        departureAddress: "Start A",
+        arrivalAddress: "End A",
+        departureLon: 1.23,
+        departureLat: 4.56,
+        arrivalLon: 7.89,
+        arrivalLat: 0.12,
+      };
+
+      // when
+      const id = await passengerUsersRepository.saveJourney(data);
+      const found = await passengerUsersRepository.findJourneyById(id);
+
+      // then
+      expect(found).toBeDefined();
+      expect(found.id).toBe(id);
+      expect(found.userId).toBe(user.id);
+      expect(found.departureAddress).toBe(data.departureAddress);
+    });
+
+    it("should return null when journey does not exist", async () => {
+      // given & when
+      const found = await passengerUsersRepository.findJourneyById(99999999);
+
+      // then
+      expect(found).toBeNull();
+    });
+  });
+
+  describe("#findJourneysByUserId", () => {
+    it("should return all journeys for a given user", async () => {
+      // given
+      const user = await databaseBuilder.factory.buildUser();
+      const otherUser = await databaseBuilder.factory.buildUser({ email: `other-${Date.now()}@example.net` });
+
+      await databaseBuilder.factory.buildPassengerJourney({
+        userId: user.id,
+        departureTime: new Date().toISOString(),
+        arrivalTime: new Date(Date.now() + 20 * 60 * 1000).toISOString(),
+        departureAddress: "A1",
+        arrivalAddress: "B1",
+        departureLon: 0,
+        departureLat: 0,
+        arrivalLon: 0,
+        arrivalLat: 0,
+      });
+      await databaseBuilder.factory.buildPassengerJourney({
+        userId: user.id,
+        departureTime: new Date().toISOString(),
+        arrivalTime: new Date(Date.now() + 40 * 60 * 1000).toISOString(),
+        departureAddress: "A2",
+        arrivalAddress: "B2",
+        departureLon: 0,
+        departureLat: 0,
+        arrivalLon: 0,
+        arrivalLat: 0,
+      });
+      await databaseBuilder.factory.buildPassengerJourney({
+        userId: otherUser.id,
+        departureTime: new Date().toISOString(),
+        arrivalTime: new Date(Date.now() + 10 * 60 * 1000).toISOString(),
+        departureAddress: "AO",
+        arrivalAddress: "BO",
+        departureLon: 0,
+        departureLat: 0,
+        arrivalLon: 0,
+        arrivalLat: 0,
+      });
+
+      // when
+      const journeys = await passengerUsersRepository.findJourneysByUserId(user.id);
+
+      // then
+      expect(Array.isArray(journeys)).toBe(true);
+      expect(journeys.length).toBeGreaterThanOrEqual(2);
+      for (const j of journeys) {
+        expect(j.userId).toBe(user.id);
+      }
+    });
+  });
+
+  describe("#removeJourneyByJourneyId", () => {
+    it("should remove an existing journey and return 1", async () => {
+      // given
+      const user = await databaseBuilder.factory.buildUser();
+      const data = await databaseBuilder.factory.buildPassengerJourney({
+        userId: user.id,
+        departureTime: new Date().toISOString(),
+        arrivalTime: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+        departureAddress: "ToRemove",
+        arrivalAddress: "ToRemoveDest",
+        departureLon: 0,
+        departureLat: 0,
+        arrivalLon: 0,
+        arrivalLat: 0,
+      });
+
+      // when
+      const removed = await passengerUsersRepository.removeJourneyByJourneyId(data.id);
+
+      // then
+      expect(removed).toBe(1);
+      const found = await knex("passenger_journeys").where({ id: data.id });
+      expect(found).toHaveLength(0);
+    });
+
+    it("should return 0 when removing non-existent journey", async () => {
+      // when
+      const removed = await passengerUsersRepository.removeJourneyByJourneyId(99999999);
+
+      // then
+      expect(removed).toBe(0);
+    });
+  });
+});

--- a/api/tests/journeys/integration/usecases/record-companion-journey-usecase.test.js
+++ b/api/tests/journeys/integration/usecases/record-companion-journey-usecase.test.js
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import databaseBuilder from "../../../../db/database-builder/index.js";
+import { knex } from "../../../../db/knex-database-connection.js";
+import usecases from "../../../../src/journeys/usecases/index.js";
+
+describe("Integration | Journeys | Usecases | Record companion journey", () => {
+  describe("database access", () => {
+    it("should save the journey in the database", async () => {
+      // given
+      const user = await databaseBuilder.factory.buildUser();
+      const data = {
+        userId: user.id,
+        departureTime: "2024-01-01T10:00:00Z",
+        arrivalTime: "2024-01-01T11:00:00Z",
+        departureAddress: "123 Main St",
+        arrivalAddress: "456 Elm St",
+        departureLon: -122.4194,
+        departureLat: 37.7749,
+        arrivalLon: -122.4194,
+        arrivalLat: 37.7749,
+      };
+
+      // when
+      const result = await usecases.recordCompanionJourneyUsecase(data);
+
+      // then
+      expect(result).toHaveProperty("journeyId");
+      const recordedJourney = await knex("companion_journeys").where({ id: result.journeyId }).first();
+      expect(Number(recordedJourney.id)).toBe(result.journeyId);
+      expect(Number(recordedJourney.userId)).toBe(user.id);
+      expect(new Date(recordedJourney.departureTime).getTime()).toBe(new Date(data.departureTime).getTime());
+      expect(new Date(recordedJourney.arrivalTime).getTime()).toBe(new Date(data.arrivalTime).getTime());
+      expect(recordedJourney.departureAddress).toBe(data.departureAddress);
+      expect(recordedJourney.arrivalAddress).toBe(data.arrivalAddress);
+      expect(parseFloat(recordedJourney.departureLon)).toBeCloseTo(-122.4194, 6);
+      expect(parseFloat(recordedJourney.arrivalLon)).toBeCloseTo(-122.4194, 6);
+      expect(parseFloat(recordedJourney.departureLat)).toBeCloseTo(37.7749, 6);
+      expect(parseFloat(recordedJourney.arrivalLat)).toBeCloseTo(37.7749, 6);
+    });
+  });
+});

--- a/api/tests/journeys/integration/usecases/record-passenger-journey-usecase.test.js
+++ b/api/tests/journeys/integration/usecases/record-passenger-journey-usecase.test.js
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import databaseBuilder from "../../../../db/database-builder/index.js";
+import { knex } from "../../../../db/knex-database-connection.js";
+import usecases from "../../../../src/journeys/usecases/index.js";
+
+describe("Integration | Journeys | Usecases | Record passenger journey", () => {
+  describe("database access", () => {
+    it("should save the journey in the database", async () => {
+      // given
+      const user = await databaseBuilder.factory.buildUser();
+      const data = {
+        userId: user.id,
+        departureTime: "2024-01-01T10:00:00Z",
+        arrivalTime: "2024-01-01T11:00:00Z",
+        departureAddress: "123 Main St",
+        arrivalAddress: "456 Elm St",
+        departureLon: -122.4194,
+        departureLat: 37.7749,
+        arrivalLon: -122.4194,
+        arrivalLat: 37.7749,
+      };
+
+      // when
+      const result = await usecases.recordPassengerJourneyUsecase(data);
+
+      // then
+      expect(result).toHaveProperty("journeyId");
+      const recordedJourney = await knex("passenger_journeys").where({ id: result.journeyId }).first();
+      expect(Number(recordedJourney.id)).toBe(result.journeyId);
+      expect(Number(recordedJourney.userId)).toBe(user.id);
+      expect(new Date(recordedJourney.departureTime).getTime()).toBe(new Date(data.departureTime).getTime());
+      expect(new Date(recordedJourney.arrivalTime).getTime()).toBe(new Date(data.arrivalTime).getTime());
+      expect(recordedJourney.departureAddress).toBe(data.departureAddress);
+      expect(recordedJourney.arrivalAddress).toBe(data.arrivalAddress);
+      expect(parseFloat(recordedJourney.departureLon)).toBeCloseTo(-122.4194, 6);
+      expect(parseFloat(recordedJourney.arrivalLon)).toBeCloseTo(-122.4194, 6);
+      expect(parseFloat(recordedJourney.departureLat)).toBeCloseTo(37.7749, 6);
+      expect(parseFloat(recordedJourney.arrivalLat)).toBeCloseTo(37.7749, 6);
+    });
+  });
+});

--- a/api/tests/journeys/unit/api/controllers/record-journey-controller.test.js
+++ b/api/tests/journeys/unit/api/controllers/record-journey-controller.test.js
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { recordJourneyController } from "../../../../../src/journeys/api/controllers/record-journey-controller.js";
+import { USER_ROLE } from "../../../../../src/shared/constants.js";
+
+describe("Unit | Journey | Api | Controller | Record journey controller", () => {
+  let res, next, usecases, findUserRepository;
+  beforeEach(function() {
+    res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn().mockReturnThis(),
+      send: vi.fn(),
+    };
+    usecases = {
+      recordCompanionJourneyUsecase: vi.fn(),
+      recordPassengerJourneyUsecase: vi.fn(),
+    };
+    findUserRepository = vi.fn();
+    next = vi.fn();
+  });
+
+  describe("valid user", () => {
+    it("should call functions and 201 status", async () => {
+      // given
+      const req = {
+        auth: {
+          userId: 123,
+        },
+        body: { a: 1 },
+      };
+      findUserRepository.mockResolvedValue({ id: 123, role: USER_ROLE.VALID });
+      usecases.recordCompanionJourneyUsecase.mockResolvedValue({ journeyId: 1 });
+
+      // when
+      await recordJourneyController(req, res, next, usecases, findUserRepository);
+
+      // then
+      expect(findUserRepository).toHaveBeenCalledWith(123);
+      expect(usecases.recordCompanionJourneyUsecase).toHaveBeenCalledWith({ userId: 123, a: 1 });
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(next).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("invalid user", () => {
+    it("should call functions and 201 status", async () => {
+      // given
+      const req = {
+        auth: {
+          userId: 123,
+        },
+        body: { a: 1 },
+      };
+      findUserRepository.mockResolvedValue({ id: 123, role: USER_ROLE.INVALID });
+      usecases.recordPassengerJourneyUsecase.mockResolvedValue({ journeyId: 1 });
+
+      // when
+      await recordJourneyController(req, res, next, usecases, findUserRepository);
+
+      // then
+      expect(findUserRepository).toHaveBeenCalledWith(123);
+      expect(usecases.recordPassengerJourneyUsecase).toHaveBeenCalledWith({ userId: 123, a: 1 });
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(next).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("user without role", () => {
+    it("should not call usecase and 400 status", async () => {
+      // given
+      const req = {
+        auth: {
+          userId: 123,
+        },
+        body: { a: 1 },
+      };
+      findUserRepository.mockResolvedValue({ id: 123 });
+
+      // when
+      await recordJourneyController(req, res, next, usecases, findUserRepository);
+
+      // then
+      expect(findUserRepository).toHaveBeenCalledWith(123);
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(next).not.toHaveBeenCalled();
+      expect(usecases.recordCompanionJourneyUsecase).not.toHaveBeenCalled();
+      expect(usecases.recordPassengerJourneyUsecase).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("error", () => {
+    it("call 500 status", async () => {
+      // given
+      const req = {
+        auth: {
+          userId: 123,
+        },
+        body: { a: 1 },
+      };
+      findUserRepository.mockRejectedValue();
+
+      // when
+      await recordJourneyController(req, res, next, usecases, findUserRepository);
+
+      // then
+      expect(findUserRepository).toHaveBeenCalledWith(123);
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(next).not.toHaveBeenCalled();
+      expect(usecases.recordCompanionJourneyUsecase).not.toHaveBeenCalled();
+      expect(usecases.recordPassengerJourneyUsecase).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
This pull request introduces a new "journeys" feature, allowing users to record journeys as either passengers or companions, depending on their user role. It includes the implementation of API endpoints, controllers, repositories, use cases, and comprehensive tests for both core logic and endpoints.

The most important changes are:

**API & Routing Integration**
* Added the `journeysRoutes` to the Express server, exposing a new POST `/api/journeys` endpoint for authenticated users to record journeys. [[1]](diffhunk://#diff-9a833c35e47340f0693af8115da337dff6f2a7576b805dc884d3437b8fec1228R8) [[2]](diffhunk://#diff-9a833c35e47340f0693af8115da337dff6f2a7576b805dc884d3437b8fec1228R32) [[3]](diffhunk://#diff-a3f12923b7a138bab55417952b021af371057468349cc986fbc343bfbe8cafefR1-R10)

**Controllers & Validation**
* Implemented `recordJourneyController` with request validation using `celebrate` and `Joi`, handling journey recording logic based on user role (passenger or companion).

**Repositories & Use Cases**
* Added repositories for both companion and passenger journeys, supporting saving, finding (by ID and user ID), and removing journeys. [[1]](diffhunk://#diff-ee35ca9da6c55555394b0ac8eaf59f4ba0be8ca851dfb49212384325448da260R1-R63) [[2]](diffhunk://#diff-87000cae8b1abebd485ac5eff414cea1518f0025314d6ccac00b6c94d86045c5R1-R63)
* Implemented use cases for recording journeys for companion and passenger users, and exposed them via a central `usecases` index. [[1]](diffhunk://#diff-cff23bae128de7a04c6f3f31aef2a85aac5167857a8fdbd2d9f6a4c5c81175e6R1-R8) [[2]](diffhunk://#diff-7b59194eceb64ecd54c6927a11ac4970b00e62fdcf8075b29cc6893d5e840591R1-R8) [[3]](diffhunk://#diff-bbb26c99eb919ac466505ae9165d2dbf37d11e2ef7da159c52efc158f805b485R1-R9)

**Testing**
* Added acceptance tests for the journeys endpoint, covering valid/invalid users, missing or malformed request bodies, and correct database integration. [[1]](diffhunk://#diff-173d4fbd214a028390722627e12c991728862a0231a9d42c57462e4dc5793fadR1-R134) [[2]](diffhunk://#diff-871c98c0af6c53055d70730184ae5d1e03777198a99de9b6c0f570f0d2eb4b04R1-R10)
* Added integration tests for the companion journeys repository, verifying save, find, and remove operations.