### PR TITLE
fix: Fix the service to send mails

### DIFF
--- a/api/config.js
+++ b/api/config.js
@@ -42,7 +42,7 @@ const configuration = (function() {
     email: {
       enabled: toBoolean(process.env.MAILING_ENABLED),
       testAccount: toBoolean(process.env.MAIL_TEST_ACCOUNT_ENABLED),
-      service: process.env.MAILING_SERVICE,
+      host: process.env.MAILING_HOST,
       port: _getNumber(process.env.MAILING_PORT, 587),
       secure: toBoolean(process.env.MAILING_SECURE),
       auth: {

--- a/api/sample.env
+++ b/api/sample.env
@@ -56,10 +56,10 @@ MAILING_ENABLED=false
 # default: false
 MAIL_TEST_ACCOUNT_ENABLED=false
 
-# Mail service
+# Mail host
 # type: string
 # required if MAILING_ENABLED is true
-# MAILING_SERVICE=
+# MAILING_HOST=
 
 # Mail secure
 # type: boolean

--- a/api/src/shared/services/emails/send-mail-service.js
+++ b/api/src/shared/services/emails/send-mail-service.js
@@ -55,7 +55,7 @@ async function sendMailService(req) {
     });
   } else {
     transporter = nodemailer.createTransport({
-      service: email.service,
+      host: email.host,
       port: email.port,
       secure: email.secure,
       auth: email.auth,

--- a/api/tests/shared/integration/services/email/send-mail-service.test.js
+++ b/api/tests/shared/integration/services/email/send-mail-service.test.js
@@ -65,7 +65,7 @@ describe("Integration | Shared | Services | Email | Send Mail", () => {
     beforeEach(() => {
       config.email.enabled = true;
       config.email.testAccount = false;
-      config.email.service = "gmail";
+      config.email.host = "smtp.gmail.com";
       config.email.port = 587;
       config.email.secure = false;
       config.email.auth = {
@@ -91,7 +91,7 @@ describe("Integration | Shared | Services | Email | Send Mail", () => {
 
       // then
       expect(nodemailer.createTransport).toHaveBeenCalledWith({
-        service: "gmail",
+        host: "smtp.gmail.com",
         port: 587,
         secure: false,
         auth: {


### PR DESCRIPTION
This pull request updates the email configuration to use `host` instead of `service` for setting up the mail transport, aligning with best practices for SMTP configuration. The changes affect configuration files, the mail service implementation, and related tests.

**Configuration changes:**

* Updated the email configuration to use `host` (`MAILING_HOST`) instead of `service` (`MAILING_SERVICE`) in `api/config.js` and `.env` files. [[1]](diffhunk://#diff-0b859be7d3fa02ad2054edc657cdf62c4e3b4c4f36c5a0c40c66096aac6d2586L45-R45) [[2]](diffhunk://#diff-84946d6e95f60d6c74d66ee462f6b7ca509aaf37a7776ad78d28dca63867321cL59-R62)

**Implementation updates:**

* Modified the mail transport creation in `send-mail-service.js` to use the `host` property instead of `service`.

**Test updates:**

* Updated integration tests to use `host` (`smtp.gmail.com`) instead of `service` (`gmail`) in email configuration and assertions. [[1]](diffhunk://#diff-6a44c18e9856665d86bb17f3a598ef67c80940129e6498fd6568da579df1aa7cL68-R68) [[2]](diffhunk://#diff-6a44c18e9856665d86bb17f3a598ef67c80940129e6498fd6568da579df1aa7cL94-R94)