### PR TITLE
fix: Update auto-merge condition for open pull requests

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   auto-merge:
-    if: (contains(github.event.pull_request.labels.*.name, 'Ready to merge') && github.event.pull_request.draft == false) || (contains(github.event.pull_request.labels.*.name, 'Auto merge') && github.event.pull_request.draft == false)
+    if: (contains(github.event.pull_request.labels.*.name, 'Ready to merge') && github.event.pull_request.draft == false && github.event.pull_request.state == 'open')
 
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This pull request makes a small update to the auto-merge workflow configuration. The change ensures that the auto-merge job only runs if the pull request is open, in addition to the existing label and draft status checks.

- Updated the `if` condition in `.github/workflows/auto-merge.yml` to require that the pull request state is `'open'` before running the auto-merge job.