### PR TITLE
tech: Labeled codecov upload

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,7 @@ updates:
     labels:
       - dependencies
       - Ready to merge
+      - no-coverage
     commit-message:
       prefix: bump
       include: scope
@@ -27,6 +28,7 @@ updates:
     open-pull-requests-limit: 2
     labels:
       - Ready to merge
+      - no-coverage
 
     commit-message:
       prefix: bump
@@ -41,6 +43,7 @@ updates:
     open-pull-requests-limit: 2
     labels:
       - Ready to merge
+      - no-coverage
 
     commit-message:
       prefix: bump
@@ -55,6 +58,7 @@ updates:
     open-pull-requests-limit: 2
     labels:
       - Ready to merge
+      - no-coverage
 
     commit-message:
       prefix: bump

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,7 @@ jobs:
         working-directory: ./api
 
       - name: Upload coverage reports to Codecov
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-coverage') }}
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -137,6 +138,7 @@ jobs:
         working-directory: ./web
 
       - name: Upload coverage reports to Codecov
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-coverage') }}
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -186,6 +188,7 @@ jobs:
         working-directory: ./admin
 
       - name: Upload coverage reports to Codecov
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-coverage') }}
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This pull request updates the Dependabot and CI configuration to support skipping code coverage uploads for certain pull requests. The main change is the introduction of a new label, `no-coverage`, which, when applied to a pull request, prevents the Codecov upload step from running in the CI workflow. This helps avoid unnecessary coverage reports for PRs where coverage is not relevant (e.g., dependency bumps).

**Dependabot configuration updates:**

* Added the `no-coverage` label to all `dependabot`-generated pull requests in `.github/dependabot.yml`. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R17) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R31) [[3]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R46) [[4]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R61)

**CI workflow improvements:**

* Updated `.github/workflows/ci.yml` to conditionally skip the "Upload coverage reports to Codecov" step if the `no-coverage` label is present on the pull request, for the `api`, `web`, and `admin` jobs. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR91) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR141) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR191)