### PR TITLE
tech: Add a code owner to notify specific teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+# This file is used to define code owners for the repository. Code owners are automatically requested for review when someone opens a pull request that modifies code they own.
+
+# api
+/api/db @edp5/data
+/api/src @edp5/back
+/api/tests @edp5/back
+/api/email-templates @edp5/fullstack
+
+# Admin
+/admin/ @edp5/front
+
+# Web
+/web/ @edp5/front
+
+# YAML files
+*.yaml @edp5/fullstack
+*.yml @edp5/fullstack


### PR DESCRIPTION
This pull request adds a `.github/codeowner` file to the repository to define code ownership and automate reviewer assignment for pull requests.

Ownership and review automation:

* Added a `.github/codeowner` file specifying code owners for different parts of the repository, including `api`, `admin`, `web`, and YAML files, to streamline review assignments.