### PR TITLE
tech: Enforce the database builder

### DIFF
--- a/api/db/database-builder/factory/build-companion-journey.js
+++ b/api/db/database-builder/factory/build-companion-journey.js
@@ -1,4 +1,5 @@
 import { knex } from "../../knex-database-connection.js";
+import { buildUser } from "./build-user.js";
 
 const TABLE_NAME = "companion_journeys";
 async function buildCompanionJourney({
@@ -12,6 +13,10 @@ async function buildCompanionJourney({
   arrivalLat = 0.0,
   arrivalLon = 0.0,
 } = {}) {
+  if (!userId) {
+    const user = await buildUser({ email: `${crypto.randomUUID()}@example.net` });
+    userId = user.id;
+  }
   const [values] = await knex(TABLE_NAME).insert({
     userId,
     departureTime,

--- a/api/db/database-builder/factory/build-found-journey.js
+++ b/api/db/database-builder/factory/build-found-journey.js
@@ -1,7 +1,36 @@
 import { JOURNEY_STATUS } from "../../../src/shared/constants.js";
 import { knex } from "../../knex-database-connection.js";
+import { buildCompanionJourney } from "./build-companion-journey.js";
+import { buildPassengerJourney } from "./build-passenger-journey.js";
 
-async function buildFoundJourney({ passengerJourneyId, companionJourneyId, status = JOURNEY_STATUS.WAITING } = {}) {
+let defaultPassengerJourneyPromise = null;
+let defaultCompanionJourneyPromise = null;
+
+async function getDefaultPassengerJourneyId() {
+  if (!defaultPassengerJourneyPromise) {
+    defaultPassengerJourneyPromise = buildPassengerJourney();
+  }
+
+  const passengerJourney = await defaultPassengerJourneyPromise;
+  return passengerJourney.id;
+}
+
+async function getDefaultCompanionJourneyId() {
+  if (!defaultCompanionJourneyPromise) {
+    defaultCompanionJourneyPromise = buildCompanionJourney();
+  }
+
+  const companionJourney = await defaultCompanionJourneyPromise;
+  return companionJourney.id;
+}
+
+async function buildFoundJourney({ passengerJourneyId = null, companionJourneyId = null, status = JOURNEY_STATUS.WAITING } = {}) {
+  if (!passengerJourneyId) {
+    passengerJourneyId = await getDefaultPassengerJourneyId();
+  }
+  if (!companionJourneyId) {
+    companionJourneyId = await getDefaultCompanionJourneyId();
+  }
   const [values] = await knex("found_journeys").insert({ passengerJourneyId, companionJourneyId, status }).returning("*");
   return values;
 }

--- a/api/db/database-builder/factory/build-passenger-journey.js
+++ b/api/db/database-builder/factory/build-passenger-journey.js
@@ -1,8 +1,9 @@
 import { knex } from "../../knex-database-connection.js";
+import { buildUser } from "./build-user.js";
 
 const TABLE_NAME = "passenger_journeys";
 async function buildPassengerJourney({
-  userId,
+  userId = null,
   departureTime = new Date("2021-01-01T00:00:00Z"),
   arrivalTime = new Date("2021-01-01T01:00:00Z"),
   departureAddress = "5 rue de la cantoche, 75015 Cherbour",
@@ -12,6 +13,10 @@ async function buildPassengerJourney({
   arrivalLat = 0.0,
   arrivalLon = 0.0,
 } = {}) {
+  if (!userId) {
+    const user = await buildUser({ email: `${crypto.randomUUID()}@example.net` });
+    userId = user.id;
+  }
   const [values] = await knex(TABLE_NAME).insert({
     userId,
     departureTime,

--- a/api/tests/journeys/integration/repositories/companion-users-repository.test.js
+++ b/api/tests/journeys/integration/repositories/companion-users-repository.test.js
@@ -44,7 +44,7 @@ describe("Integration | Journeys | Repositories | Companion users repository", (
     it("should return the journey when it exists", async () => {
       // given
       const user = await databaseBuilder.factory.buildUser();
-      const data = {
+      const companionJourney = await databaseBuilder.factory.buildCompanionJourney({
         userId: user.id,
         departureTime: new Date().toISOString(),
         arrivalTime: new Date(Date.now() + 30 * 60 * 1000).toISOString(), // +30m
@@ -54,17 +54,16 @@ describe("Integration | Journeys | Repositories | Companion users repository", (
         departureLat: 4.56,
         arrivalLon: 7.89,
         arrivalLat: 0.12,
-      };
+      });
 
       // when
-      const id = await companionUsersRepository.saveJourney(data);
-      const found = await companionUsersRepository.findJourneyById(id);
+      const found = await companionUsersRepository.findJourneyById(companionJourney.id);
 
       // then
       expect(found).toBeDefined();
-      expect(found.id).toBe(id);
+      expect(found.id).toBe(companionJourney.id);
       expect(found.userId).toBe(user.id);
-      expect(found.departureAddress).toBe(data.departureAddress);
+      expect(found.departureAddress).toBe(companionJourney.departureAddress);
     });
 
     it("should return null when journey does not exist", async () => {

--- a/api/tests/journeys/integration/repositories/passenger-users-repository.test.js
+++ b/api/tests/journeys/integration/repositories/passenger-users-repository.test.js
@@ -44,7 +44,7 @@ describe("Integration | Journeys | Repositories | Passenger users repository", (
     it("should return the journey when it exists", async () => {
       // given
       const user = await databaseBuilder.factory.buildUser();
-      const data = {
+      const passengerJourney = await databaseBuilder.factory.buildPassengerJourney({
         userId: user.id,
         departureTime: new Date().toISOString(),
         arrivalTime: new Date(Date.now() + 30 * 60 * 1000).toISOString(), // +30m
@@ -54,17 +54,16 @@ describe("Integration | Journeys | Repositories | Passenger users repository", (
         departureLat: 4.56,
         arrivalLon: 7.89,
         arrivalLat: 0.12,
-      };
+      });
 
       // when
-      const id = await passengerUsersRepository.saveJourney(data);
-      const found = await passengerUsersRepository.findJourneyById(id);
+      const found = await passengerUsersRepository.findJourneyById(passengerJourney.id);
 
       // then
       expect(found).toBeDefined();
-      expect(found.id).toBe(id);
+      expect(found.id).toBe(passengerJourney.id);
       expect(found.userId).toBe(user.id);
-      expect(found.departureAddress).toBe(data.departureAddress);
+      expect(found.departureAddress).toBe(passengerJourney.departureAddress);
     });
 
     it("should return null when journey does not exist", async () => {


### PR DESCRIPTION
This pull request enhances the test data builder functions for journeys by making user and journey creation more robust and automatic. Now, if a required `userId` or journey ID is not provided, the builder functions will automatically create the necessary user or journey, ensuring that all dependencies are satisfied without manual setup.

**Improvements to journey builder functions:**

* `build-companion-journey.js` and `build-passenger-journey.js`: Updated to automatically create a user with a default email if `userId` is not provided, ensuring that every journey has an associated user. [[1]](diffhunk://#diff-5a066159cb4ac99ba3466b6787a13319826470d9a4cddb061c7d8ca836c45a36R2) [[2]](diffhunk://#diff-5a066159cb4ac99ba3466b6787a13319826470d9a4cddb061c7d8ca836c45a36R16-R19) [[3]](diffhunk://#diff-b9ff020e82882066ce03603968431f24363ade0da3aad6fcfa0078418d6520a3R2-R6) [[4]](diffhunk://#diff-b9ff020e82882066ce03603968431f24363ade0da3aad6fcfa0078418d6520a3R16-R19)

* [`build-found-journey.js`](diffhunk://#diff-aeac2d794ff7d232f66f45ab3ab1d73f7fcc99e84282873799998f4ddecbcbebR3-R14): Enhanced to automatically create `passengerJourney` and `companionJourney` if their IDs are not provided, streamlining test data setup and reducing boilerplate in tests.

These changes make the test data factories more reliable and easier to use, especially in automated tests where explicit setup of all dependencies can be cumbersome.