### PR TITLE
feat: Create a route to update status of found journey

### DIFF
--- a/api/db/database-builder/factory/build-found-journey.js
+++ b/api/db/database-builder/factory/build-found-journey.js
@@ -13,14 +13,14 @@ async function getDefaultCompanionJourneyId() {
   return companionJourney.id;
 }
 
-async function buildFoundJourney({ passengerJourneyId = null, companionJourneyId = null, status = JOURNEY_STATUS.WAITING } = {}) {
+async function buildFoundJourney({ passengerJourneyId = null, companionJourneyId = null, companionStatus = JOURNEY_STATUS.WAITING, passengerStatus = JOURNEY_STATUS.WAITING } = {}) {
   if (!passengerJourneyId) {
     passengerJourneyId = await getDefaultPassengerJourneyId();
   }
   if (!companionJourneyId) {
     companionJourneyId = await getDefaultCompanionJourneyId();
   }
-  const [values] = await knex("found_journeys").insert({ passengerJourneyId, companionJourneyId, status }).returning("*");
+  const [values] = await knex("found_journeys").insert({ passengerJourneyId, companionJourneyId, passengerStatus, companionStatus }).returning("*");
   return values;
 }
 

--- a/api/db/database-builder/factory/build-user.js
+++ b/api/db/database-builder/factory/build-user.js
@@ -1,7 +1,7 @@
 import { generatePassword } from "../../../src/identities-access-management/services/password-service.js";
 import { DEFAULT_USER_TYPE } from "../../../src/shared/constants.js";
 import { knex } from "../../knex-database-connection.js";
-async function buildUser({ firstname = "John", lastname = "Doe", email = "john.doe@example.net", birthday = "01/01/1970", created_at = new Date(), updated_at = new Date(), isActive = true, isChecked = true, hashedPassword = null, userType = DEFAULT_USER_TYPE, lastLoggedAt = null, role = null, genre = null, disabilities = null } = {}) {
+async function buildUser({ firstname = "John", lastname = "Doe", email = `john.doe+${crypto.randomUUID()}@example.net`, birthday = "01/01/1970", created_at = new Date(), updated_at = new Date(), isActive = true, isChecked = true, hashedPassword = null, userType = DEFAULT_USER_TYPE, lastLoggedAt = null, role = null, genre = null, disabilities = null } = {}) {
   if (!hashedPassword) {
     hashedPassword = await generatePassword("password");
   }

--- a/api/db/migrations/20260605151835_separate-columns-for-companion-and-passenger-status.js
+++ b/api/db/migrations/20260605151835_separate-columns-for-companion-and-passenger-status.js
@@ -1,0 +1,28 @@
+import { JOURNEY_STATUS } from "../../src/shared/constants.js";
+
+const TABLE_NAME = "found_journeys";
+
+/**
+ * @param { import("knex").Knex } knex - The Knex instance
+ * @returns { Promise<void> }
+ */
+async function up(knex) {
+  await knex.schema.alterTable(TABLE_NAME, function(table) {
+    table.dropColumns("status");
+    table.string("companionStatus").notNullable().defaultTo(JOURNEY_STATUS.WAITING).comment("The status of the companion");
+    table.string("passengerStatus").notNullable().defaultTo(JOURNEY_STATUS.WAITING).comment("The status of the passenger");
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex - The Knex instance
+ * @returns { Promise<void> }
+ */
+async function down(knex) {
+  await knex.schema.alterTable(TABLE_NAME, function(table) {
+    table.dropColumns("companionStatus", "passengerStatus");
+    table.string("status").notNullable().defaultTo(JOURNEY_STATUS.WAITING);
+  });
+};
+
+export { down, up };

--- a/api/db/seeds/data/journeys.js
+++ b/api/db/seeds/data/journeys.js
@@ -234,7 +234,7 @@ async function acceptedJourney(databasebuilder) {
     arrivalLon: 6.024053,
   });
 
-  await databasebuilder.factory.buildFoundJourney({ passengerJourneyId: passenger.id, companionJourneyId: companion.id, status: JOURNEY_STATUS.ACCEPTED });
+  await databasebuilder.factory.buildFoundJourney({ passengerJourneyId: passenger.id, companionJourneyId: companion.id, companionStatus: JOURNEY_STATUS.ACCEPTED, passengerStatus: JOURNEY_STATUS.ACCEPTED });
 }
 
 async function journeys(databasebuilder) {

--- a/api/scripts/generate-swagger-jsdoc.js
+++ b/api/scripts/generate-swagger-jsdoc.js
@@ -65,7 +65,9 @@ function extractDocumentedEndpoints(fileContent) {
       const method = methodMatch[1].toLowerCase();
 
       if (HTTP_METHODS.includes(method)) {
-        documentedEndpoints.add(`${method} ${endpointPath}`);
+        documentedEndpoints.add(
+          `${method} ${_normalizePath(endpointPath)}`,
+        );
       }
     }
   }
@@ -170,6 +172,19 @@ async function writeTemplateFiles(missingRoutes) {
   await fs.writeFile(filePath, content, "utf8");
 }
 
+
+/**
+ * Normalizes route paths by converting Express-style parameters to Swagger format and removing extra slashes.
+ * @param {string} path - The original route path.
+ * @returns {*} - Normalized route path.
+ * @private
+ */
+function _normalizePath(path) {
+  return path
+    .replace(/:([A-Za-z0-9_]+)/g, "{$1}")
+    .replace(/\/+/g, "/");
+}
+
 /**
  * Generate swagger templates for undocumented routes.
  * @returns {Promise<void>} Resolves when complete.
@@ -185,7 +200,8 @@ async function main() {
     const relativeFilePath = path.relative(ROOT_DIRECTORY, routeFile);
 
     for (const route of declaredRoutes) {
-      const endpointKey = `${route.method} ${route.path}`;
+      const endpointKey =
+        `${route.method} ${_normalizePath(route.path)}`;
 
       if (!documentedEndpoints.has(endpointKey)) {
         missingRoutes.push({

--- a/api/src/journeys/api/controllers/update-found-journey-status-controller.js
+++ b/api/src/journeys/api/controllers/update-found-journey-status-controller.js
@@ -1,0 +1,67 @@
+import { celebrate, Joi, Segments } from "celebrate";
+
+import { logger } from "../../../../logger.js";
+import { findUserById } from "../../../identities-access-management/repositories/user-repository.js";
+import { USER_ROLE } from "../../../shared/constants.js";
+import { UserHasNoRole } from "../../errors.js";
+import usecases from "../../usecases/index.js";
+
+const updateFoundJourneyStatusSchema = celebrate({
+  [Segments.PARAMS]: Joi.object({
+    foundJourneyId: Joi.number().required().positive().required(),
+  }),
+  [Segments.BODY]: Joi.object({
+    updatedStatus: Joi.bool().required(),
+  }),
+});
+
+/**
+ * Controller to update the found journey status, it will check the user role and update the status accordingly
+ * @param {object} req - The request object, it should contain the user id in the auth property, the found journey id in the params and the updated status in the body
+ * @param {object} res - The response object, it will return a 201 status code if the status is updated successfully, otherwise it will return a 500 status code
+ * @param {Function} next - The next function to call in case of an error, it will pass the error to the error handling middleware
+ * @param {Function} acceptCompanionUsecase - The usecase to accept the companion status, it will be injected for testing purposes, it should receive an object with the user id and the found journey id and return a promise
+ * @param {Function} rejectCompanionUsecase - The usecase to reject the companion status, it will be injected for testing purposes, it should receive an object with the user id and the found journey id and return a promise
+ * @param {Function} acceptPassengerUsecase - The usecase to accept the passenger status, it will be injected for testing purposes, it should receive an object with the user id and the found journey id and return a promise
+ * @param {Function} rejectPassengerUsecase - The usecase to reject the passenger status, it will be injected for testing purposes, it should receive an object with the user id and the found journey id and return a promise
+ * @param {Function} findUser - The function to find the user by id, it will be injected for testing purposes, it should receive the user id and return a promise that resolves to the user object
+ * @returns {Promise<*>} - It will return a promise that resolves to the response object, it will return a 201 status code if the status is updated successfully, otherwise it will return a 500 status code
+ */
+async function updateFoundJourneyStatusController(
+  req,
+  res,
+  next,
+  acceptCompanionUsecase = usecases.acceptFoundJourneyCompanionStatusUsecase,
+  rejectCompanionUsecase = usecases.rejectFoundJourneyCompanionStatusUsecase,
+  acceptPassengerUsecase = usecases.acceptFoundJourneyPassengerStatusUsecase,
+  rejectPassengerUsecase = usecases.rejectFoundJourneyPassengerStatusUsecase,
+  findUser = findUserById,
+) {
+  const { auth, body, params } = req;
+  try {
+    const user = await findUser(auth.userId);
+    switch (user.role) {
+    case USER_ROLE.INVALID:
+      if (body.updatedStatus) {
+        await acceptPassengerUsecase({ userId: auth.userId, foundJourneyId: params.foundJourneyId });
+      } else {
+        await rejectPassengerUsecase({ userId: auth.userId, foundJourneyId: params.foundJourneyId });
+      }
+      return res.status(201).send();
+    case USER_ROLE.VALID:
+      if (body.updatedStatus) {
+        await acceptCompanionUsecase({ userId: auth.userId, foundJourneyId: params.foundJourneyId });
+      } else {
+        await rejectCompanionUsecase({ userId: auth.userId, foundJourneyId: params.foundJourneyId });
+      }
+      return res.status(201).send();
+    default:
+      throw new UserHasNoRole();
+    }
+  } catch (error) {
+    logger.error({ err: error }, "Error updating found journey status");
+    return next(error);
+  }
+}
+
+export { updateFoundJourneyStatusController, updateFoundJourneyStatusSchema };

--- a/api/src/journeys/api/routes/journeys-routes.js
+++ b/api/src/journeys/api/routes/journeys-routes.js
@@ -3,6 +3,10 @@ import express from "express";
 import { authMiddleware } from "../../../shared/infrastructure/middlewares/auth-middleware.js";
 import { getJourneyController, getJourneyControllerSchema } from "../controllers/get-journey-controller.js";
 import { recordJourneyController, recordJourneyControllerSchema } from "../controllers/record-journey-controller.js";
+import {
+  updateFoundJourneyStatusController,
+  updateFoundJourneyStatusSchema,
+} from "../controllers/update-found-journey-status-controller.js";
 
 const journeysRoutes = express.Router();
 
@@ -152,6 +156,56 @@ journeysRoutes.post("/api/journeys", authMiddleware, recordJourneyControllerSche
  *       500:
  *         description: Internal server error
  */
-journeysRoutes.get("/api/journeys/:journeyId", authMiddleware, getJourneyControllerSchema, getJourneyController);
+journeysRoutes.get(
+  "/api/journeys/:journeyId",
+  authMiddleware,
+  getJourneyControllerSchema,
+  getJourneyController,
+);
+
+/**
+ * @swagger
+ * /api/journeys/found/{foundJourneyId}:
+ *   put:
+ *     summary: Update found journey status
+ *     description: Updates the status of a found journey for the authenticated user.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: foundJourneyId
+ *         required: true
+ *         schema:
+ *           type: integer
+ *         description: The ID of the found journey to update
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - updatedStatus
+ *             properties:
+ *               updatedStatus:
+ *                 type: boolean
+ *     responses:
+ *       204:
+ *         description: Found journey status updated successfully
+ *       400:
+ *         description: Validation failed
+ *       401:
+ *         description: Unauthorized
+ *       404:
+ *         description: Found journey not found
+ *       500:
+ *         description: Internal server error
+ */
+journeysRoutes.put(
+  "/api/journeys/found/:foundJourneyId",
+  authMiddleware,
+  updateFoundJourneyStatusSchema,
+  updateFoundJourneyStatusController,
+);
 
 export default journeysRoutes;

--- a/api/src/journeys/errors.js
+++ b/api/src/journeys/errors.js
@@ -10,6 +10,42 @@ class JourneyNotFound extends DomainError {
 }
 
 /**
+ * Throw when the journey is not of this user
+ */
+class JourneyIsNotOfThisUser extends DomainError {
+  constructor() {
+    super("Journey is not of this user", 403);
+  }
+}
+
+/**
+ * Throw when the journey is already accepted
+ */
+class AlreadyAccepted extends DomainError {
+  constructor() {
+    super("Journey is already accepted", 400);
+  }
+}
+
+/**
+ * Throw when journey is already rejected
+ */
+class AlreadyRejected extends DomainError {
+  constructor() {
+    super("Journey is already rejected", 400);
+  }
+}
+
+/**
+ * Throw when journey is already cancelled
+ */
+class AlreadyCancelled extends DomainError {
+  constructor() {
+    super("Journey is already cancelled", 400);
+  }
+}
+
+/**
  * Throw when user has no role
  */
 class UserHasNoRole extends DomainError {
@@ -18,4 +54,4 @@ class UserHasNoRole extends DomainError {
   }
 }
 
-export { JourneyNotFound, UserHasNoRole };
+export { AlreadyAccepted, AlreadyCancelled, AlreadyRejected, JourneyIsNotOfThisUser, JourneyNotFound, UserHasNoRole };

--- a/api/src/journeys/repositories/found-journeys-repository.js
+++ b/api/src/journeys/repositories/found-journeys-repository.js
@@ -1,0 +1,39 @@
+import { knex } from "../../../db/knex-database-connection.js";
+import { DomainTransaction } from "../../shared/infrastructure/DomainTransaction.js";
+
+const TABLE_NAME = "found_journeys";
+
+/**
+ * Finds a found journey by its ID.
+ * @param {number} foundJourneyId - The ID of the found journey to retrieve.
+ * @returns {Promise<object | null>} The found journey object if found, or null if not found.
+ */
+async function findFoundJourneyByFoundJourneyId(foundJourneyId) {
+  const foundJourney = await knex(TABLE_NAME).where({ id: foundJourneyId }).first();
+  return foundJourney || null;
+}
+
+/**
+ * Updates the passenger status of a found journey by its ID.
+ * @param {object} param0 - An object containing the found journey ID and the new passenger status.
+ * @param {number} param0.foundJourneyId - The ID of the found journey to update.
+ * @param {string} param0.status - The new passenger status to set for the found journey.
+ */
+async function updateFoundJourneyPassengerStatusByFoundJourneyId({ foundJourneyId, status }) {
+  const knexCon = DomainTransaction.getConnection();
+  await knexCon(TABLE_NAME).where({ id: foundJourneyId }).update({ passengerStatus: status });
+}
+
+/**
+ * Updates the companion status of a found journey by its ID.
+ * @param {object} param0 - The parameters for updating the companion status of a found journey.
+ * @param {number} param0.foundJourneyId - The ID of the found journey to update.
+ * @param {string} param0.status - The new companion status to set for the found journey.
+ */
+async function updateFoundJourneyCompanionStatusByFoundJourneyId({ foundJourneyId, status }) {
+  const knexCon = DomainTransaction.getConnection();
+  await knexCon(TABLE_NAME).where({ id: foundJourneyId }).update({ companionStatus: status });
+}
+
+
+export { findFoundJourneyByFoundJourneyId, updateFoundJourneyCompanionStatusByFoundJourneyId, updateFoundJourneyPassengerStatusByFoundJourneyId };

--- a/api/src/journeys/usecases/accept-found-journey-companion-status-usecase.js
+++ b/api/src/journeys/usecases/accept-found-journey-companion-status-usecase.js
@@ -1,0 +1,35 @@
+import { JOURNEY_STATUS } from "../../shared/constants.js";
+import { JourneyIsNotOfThisUser, JourneyNotFound } from "../errors.js";
+import { findJourneyById } from "../repositories/companion-users-repository.js";
+import {
+  findFoundJourneyByFoundJourneyId,
+  updateFoundJourneyCompanionStatusByFoundJourneyId,
+} from "../repositories/found-journeys-repository.js";
+import { checkFoundJourneyStatus } from "../utils/check-found-journey-status.js";
+import { updateFoundJourneyStatusUsecase } from "./update-found-journey-status-usecase.js";
+
+/**
+ * Update the status of a companion found journey
+ * @param {object} param0 - Params data
+ * @param {number} param0.userId - The id of user
+ * @param {number} param0.foundJourneyId - The id of found journey
+ * @returns {Promise<void>}
+ */
+async function acceptFoundJourneyCompanionStatusUsecase({
+  userId,
+  foundJourneyId,
+}) {
+  const foundJourney = await findFoundJourneyByFoundJourneyId(foundJourneyId);
+  if (!foundJourney) {
+    throw new JourneyNotFound();
+  }
+  const journey = await findJourneyById(foundJourney.companionJourneyId);
+  if (journey.userId === userId) {
+    checkFoundJourneyStatus({ oupdatedStatus: foundJourney.companionStatus, updatedStatus: JOURNEY_STATUS.ACCEPTED });
+    await updateFoundJourneyStatusUsecase({ updateRepository: updateFoundJourneyCompanionStatusByFoundJourneyId, foundJourneyId, updatedStatus: JOURNEY_STATUS.ACCEPTED });
+  } else {
+    throw new JourneyIsNotOfThisUser();
+  }
+}
+
+export { acceptFoundJourneyCompanionStatusUsecase };

--- a/api/src/journeys/usecases/accept-found-journey-passenger-status-usecase.js
+++ b/api/src/journeys/usecases/accept-found-journey-passenger-status-usecase.js
@@ -1,0 +1,35 @@
+import { JOURNEY_STATUS } from "../../shared/constants.js";
+import { JourneyIsNotOfThisUser, JourneyNotFound } from "../errors.js";
+import {
+  findFoundJourneyByFoundJourneyId,
+  updateFoundJourneyPassengerStatusByFoundJourneyId,
+} from "../repositories/found-journeys-repository.js";
+import { findJourneyById } from "../repositories/passenger-users-repository.js";
+import { checkFoundJourneyStatus } from "../utils/check-found-journey-status.js";
+import { updateFoundJourneyStatusUsecase } from "./update-found-journey-status-usecase.js";
+
+/**
+ * Update the status of a passenger found journey
+ * @param {object} param0 - Params data
+ * @param {number} param0.userId - The id of user
+ * @param {number} param0.foundJourneyId - The id of found journey
+ * @returns {Promise<void>}
+ */
+async function acceptFoundJourneyPassengerStatusUsecase({
+  userId,
+  foundJourneyId,
+}) {
+  const foundJourney = await findFoundJourneyByFoundJourneyId(foundJourneyId);
+  if (!foundJourney) {
+    throw new JourneyNotFound();
+  }
+  const journey = await findJourneyById(foundJourney.passengerJourneyId);
+  if (journey.userId === userId) {
+    checkFoundJourneyStatus({ oupdatedStatus: foundJourney.passengerStatus, updatedStatus: JOURNEY_STATUS.ACCEPTED });
+    await updateFoundJourneyStatusUsecase({ updateRepository: updateFoundJourneyPassengerStatusByFoundJourneyId, foundJourneyId, updatedStatus: JOURNEY_STATUS.ACCEPTED });
+  } else {
+    throw new JourneyIsNotOfThisUser();
+  }
+}
+
+export { acceptFoundJourneyPassengerStatusUsecase };

--- a/api/src/journeys/usecases/cancel-found-journey-companion-status-usecase.js
+++ b/api/src/journeys/usecases/cancel-found-journey-companion-status-usecase.js
@@ -1,0 +1,35 @@
+import { JOURNEY_STATUS } from "../../shared/constants.js";
+import { JourneyIsNotOfThisUser, JourneyNotFound } from "../errors.js";
+import { findJourneyById } from "../repositories/companion-users-repository.js";
+import {
+  findFoundJourneyByFoundJourneyId,
+  updateFoundJourneyCompanionStatusByFoundJourneyId,
+} from "../repositories/found-journeys-repository.js";
+import { checkFoundJourneyStatus } from "../utils/check-found-journey-status.js";
+import { updateFoundJourneyStatusUsecase } from "./update-found-journey-status-usecase.js";
+
+/**
+ * Update the status of a companion found journey
+ * @param {object} param0 - Params data
+ * @param {number} param0.userId - The id of user
+ * @param {number} param0.foundJourneyId - The id of found journey
+ * @returns {Promise<void>}
+ */
+async function cancelFoundJourneyCompanionStatusUsecase({
+  userId,
+  foundJourneyId,
+}) {
+  const foundJourney = await findFoundJourneyByFoundJourneyId(foundJourneyId);
+  if (!foundJourney) {
+    throw new JourneyNotFound();
+  }
+  const journey = await findJourneyById(foundJourney.companionJourneyId);
+  if (journey.userId === userId) {
+    checkFoundJourneyStatus({ oupdatedStatus: foundJourney.companionStatus, updatedStatus: JOURNEY_STATUS.CANCELLED });
+    await updateFoundJourneyStatusUsecase({ updateRepository: updateFoundJourneyCompanionStatusByFoundJourneyId, foundJourneyId, updatedStatus: JOURNEY_STATUS.CANCELLED });
+  } else {
+    throw new JourneyIsNotOfThisUser();
+  }
+}
+
+export { cancelFoundJourneyCompanionStatusUsecase };

--- a/api/src/journeys/usecases/cancel-found-journey-passenger-status-usecase.js
+++ b/api/src/journeys/usecases/cancel-found-journey-passenger-status-usecase.js
@@ -1,0 +1,35 @@
+import { JOURNEY_STATUS } from "../../shared/constants.js";
+import { JourneyIsNotOfThisUser, JourneyNotFound } from "../errors.js";
+import {
+  findFoundJourneyByFoundJourneyId,
+  updateFoundJourneyPassengerStatusByFoundJourneyId,
+} from "../repositories/found-journeys-repository.js";
+import { findJourneyById } from "../repositories/passenger-users-repository.js";
+import { checkFoundJourneyStatus } from "../utils/check-found-journey-status.js";
+import { updateFoundJourneyStatusUsecase } from "./update-found-journey-status-usecase.js";
+
+/**
+ * Update the status of a passenger found journey
+ * @param {object} param0 - Params data
+ * @param {number} param0.userId - The id of user
+ * @param {number} param0.foundJourneyId - The id of found journey
+ * @returns {Promise<void>}
+ */
+async function cancelFoundJourneyPassengerStatusUsecase({
+  userId,
+  foundJourneyId,
+}) {
+  const foundJourney = await findFoundJourneyByFoundJourneyId(foundJourneyId);
+  if (!foundJourney) {
+    throw new JourneyNotFound();
+  }
+  const journey = await findJourneyById(foundJourney.passengerJourneyId);
+  if (journey.userId === userId) {
+    checkFoundJourneyStatus({ oupdatedStatus: foundJourney.passengerStatus, updatedStatus: JOURNEY_STATUS.CANCELLED });
+    await updateFoundJourneyStatusUsecase({ updateRepository: updateFoundJourneyPassengerStatusByFoundJourneyId, foundJourneyId, updatedStatus: JOURNEY_STATUS.CANCELLED });
+  } else {
+    throw new JourneyIsNotOfThisUser();
+  }
+}
+
+export { cancelFoundJourneyPassengerStatusUsecase };

--- a/api/src/journeys/usecases/index.js
+++ b/api/src/journeys/usecases/index.js
@@ -1,13 +1,25 @@
+import { acceptFoundJourneyCompanionStatusUsecase } from "./accept-found-journey-companion-status-usecase.js";
+import { acceptFoundJourneyPassengerStatusUsecase } from "./accept-found-journey-passenger-status-usecase.js";
+import { cancelFoundJourneyCompanionStatusUsecase } from "./cancel-found-journey-companion-status-usecase.js";
+import { cancelFoundJourneyPassengerStatusUsecase } from "./cancel-found-journey-passenger-status-usecase.js";
 import { getCompanionJourneyUsecase } from "./get-companion-journey-usecase.js";
 import { getPassengerJourneyUsecase } from "./get-passenger-journey-usecase.js";
 import { recordCompanionJourneyUsecase } from "./record-companion-journey-usecase.js";
 import { recordPassengerJourneyUsecase } from "./record-passenger-journey-usecase.js";
+import { rejectFoundJourneyCompanionStatusUsecase } from "./reject-found-journey-companion-status-usecase.js";
+import { rejectFoundJourneyPassengerStatusUsecase } from "./reject-found-journey-passenger-status-usecase.js";
 
 const usecases = {
   getCompanionJourneyUsecase,
   getPassengerJourneyUsecase,
   recordCompanionJourneyUsecase,
   recordPassengerJourneyUsecase,
+  acceptFoundJourneyCompanionStatusUsecase,
+  cancelFoundJourneyCompanionStatusUsecase,
+  rejectFoundJourneyCompanionStatusUsecase,
+  acceptFoundJourneyPassengerStatusUsecase,
+  cancelFoundJourneyPassengerStatusUsecase,
+  rejectFoundJourneyPassengerStatusUsecase,
 };
 
 export default usecases;

--- a/api/src/journeys/usecases/reject-found-journey-companion-status-usecase.js
+++ b/api/src/journeys/usecases/reject-found-journey-companion-status-usecase.js
@@ -1,0 +1,35 @@
+import { JOURNEY_STATUS } from "../../shared/constants.js";
+import { JourneyIsNotOfThisUser, JourneyNotFound } from "../errors.js";
+import { findJourneyById } from "../repositories/companion-users-repository.js";
+import {
+  findFoundJourneyByFoundJourneyId,
+  updateFoundJourneyCompanionStatusByFoundJourneyId,
+} from "../repositories/found-journeys-repository.js";
+import { checkFoundJourneyStatus } from "../utils/check-found-journey-status.js";
+import { updateFoundJourneyStatusUsecase } from "./update-found-journey-status-usecase.js";
+
+/**
+ * Update the status of a companion found journey
+ * @param {object} param0 - Params data
+ * @param {number} param0.userId - The id of user
+ * @param {number} param0.foundJourneyId - The id of found journey
+ * @returns {Promise<void>}
+ */
+async function rejectFoundJourneyCompanionStatusUsecase({
+  userId,
+  foundJourneyId,
+}) {
+  const foundJourney = await findFoundJourneyByFoundJourneyId(foundJourneyId);
+  if (!foundJourney) {
+    throw new JourneyNotFound();
+  }
+  const journey = await findJourneyById(foundJourney.companionJourneyId);
+  if (journey.userId === userId) {
+    checkFoundJourneyStatus({ oupdatedStatus: foundJourney.companionStatus, updatedStatus: JOURNEY_STATUS.REJECTED });
+    await updateFoundJourneyStatusUsecase({ updateRepository: updateFoundJourneyCompanionStatusByFoundJourneyId, foundJourneyId, updatedStatus: JOURNEY_STATUS.REJECTED });
+  } else {
+    throw new JourneyIsNotOfThisUser();
+  }
+}
+
+export { rejectFoundJourneyCompanionStatusUsecase };

--- a/api/src/journeys/usecases/reject-found-journey-passenger-status-usecase.js
+++ b/api/src/journeys/usecases/reject-found-journey-passenger-status-usecase.js
@@ -1,0 +1,35 @@
+import { JOURNEY_STATUS } from "../../shared/constants.js";
+import { JourneyIsNotOfThisUser, JourneyNotFound } from "../errors.js";
+import {
+  findFoundJourneyByFoundJourneyId,
+  updateFoundJourneyPassengerStatusByFoundJourneyId,
+} from "../repositories/found-journeys-repository.js";
+import { findJourneyById } from "../repositories/passenger-users-repository.js";
+import { checkFoundJourneyStatus } from "../utils/check-found-journey-status.js";
+import { updateFoundJourneyStatusUsecase } from "./update-found-journey-status-usecase.js";
+
+/**
+ * Update the status of a passenger found journey
+ * @param {object} param0 - Params data
+ * @param {number} param0.userId - The id of user
+ * @param {number} param0.foundJourneyId - The id of found journey
+ * @returns {Promise<void>}
+ */
+async function rejectFoundJourneyPassengerStatusUsecase({
+  userId,
+  foundJourneyId,
+}) {
+  const foundJourney = await findFoundJourneyByFoundJourneyId(foundJourneyId);
+  if (!foundJourney) {
+    throw new JourneyNotFound();
+  }
+  const journey = await findJourneyById(foundJourney.passengerJourneyId);
+  if (journey.userId === userId) {
+    checkFoundJourneyStatus({ oupdatedStatus: foundJourney.passengerStatus, updatedStatus: JOURNEY_STATUS.REJECTED });
+    await updateFoundJourneyStatusUsecase({ updateRepository: updateFoundJourneyPassengerStatusByFoundJourneyId, foundJourneyId, updatedStatus: JOURNEY_STATUS.REJECTED });
+  } else {
+    throw new JourneyIsNotOfThisUser();
+  }
+}
+
+export { rejectFoundJourneyPassengerStatusUsecase };

--- a/api/src/journeys/usecases/update-found-journey-status-usecase.js
+++ b/api/src/journeys/usecases/update-found-journey-status-usecase.js
@@ -1,0 +1,21 @@
+import { DomainTransaction } from "../../shared/infrastructure/DomainTransaction.js";
+
+/**
+ * Update the status of found journey
+ * @param {object} param0 - Params data
+ * @param {Function} param0.updateRepository - Function to update status
+ * @param {number} param0.foundJourneyId - The id of found journey to update
+ * @param {string} param0.updatedStatus - The new status of user journey
+ * @returns {Promise<void>}
+ */
+async function updateFoundJourneyStatusUsecase({
+  updateRepository,
+  foundJourneyId,
+  updatedStatus,
+}) {
+  await DomainTransaction.execute(async () => {
+    await updateRepository({ foundJourneyId, status: updatedStatus });
+  });
+}
+
+export { updateFoundJourneyStatusUsecase };

--- a/api/src/journeys/utils/check-found-journey-status.js
+++ b/api/src/journeys/utils/check-found-journey-status.js
@@ -1,0 +1,28 @@
+import { JOURNEY_STATUS } from "../../shared/constants.js";
+import {
+  AlreadyAccepted,
+  AlreadyCancelled,
+  AlreadyRejected,
+} from "../errors.js";
+
+function checkFoundJourneyStatus({ oupdatedStatus, updatedStatus }) {
+  const errorStatus = {
+    [JOURNEY_STATUS.ACCEPTED]: () => {
+      throw new AlreadyAccepted();
+    },
+    [JOURNEY_STATUS.CANCELLED]: () => {
+      throw new AlreadyCancelled();
+    },
+    [JOURNEY_STATUS.REJECTED]: () => {
+      throw new AlreadyRejected();
+    },
+  };
+
+  if (oupdatedStatus === updatedStatus) {
+    errorStatus[updatedStatus]?.();
+  } else if (oupdatedStatus !== JOURNEY_STATUS.WAITING) {
+    errorStatus[oupdatedStatus]?.();
+  }
+}
+
+export { checkFoundJourneyStatus };

--- a/api/src/shared/constants.js
+++ b/api/src/shared/constants.js
@@ -25,10 +25,6 @@ export const DEFAULT_USER_TYPE = USER_TYPES.USER;
 export const JOURNEY_STATUS = {
   /** Waiting for confirmation */
   WAITING: "waiting",
-  /** Journey accepted by companion but waiting passenger */
-  WAITING_PASSENGER: "waiting_passenger",
-  /** Journey accepted by passenger but waiting companion */
-  WAITING_COMPANION: "waiting_companion",
   /** Journey accepted by both parties */
   ACCEPTED: "accepted",
   /** Journey rejected */

--- a/api/tests/journeys/acceptance/journeys-routes.test.js
+++ b/api/tests/journeys/acceptance/journeys-routes.test.js
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 import databaseBuilder from "../../../db/database-builder/index.js";
 import { knex } from "../../../db/knex-database-connection.js";
 import server from "../../../server.js";
-import { USER_ROLE } from "../../../src/shared/constants.js";
+import { JOURNEY_STATUS, USER_ROLE } from "../../../src/shared/constants.js";
 import { generateAuthenticatedUser } from "../../helpers/generate-authenticated-user.js";
 
 describe("Acceptance | Journeys | Journey routes", () => {
@@ -164,8 +164,14 @@ describe("Acceptance | Journeys | Journey routes", () => {
 
     it("should return 404 when the journey belongs to another user", async () => {
       // given
-      const owner = await databaseBuilder.factory.buildUser({ role: USER_ROLE.INVALID, email: `owner-${crypto.randomUUID()}@example.net` });
-      const otherUser = await databaseBuilder.factory.buildUser({ role: USER_ROLE.INVALID, email: `other-${crypto.randomUUID()}@example.net` });
+      const owner = await databaseBuilder.factory.buildUser({
+        role: USER_ROLE.INVALID,
+        email: `owner-${crypto.randomUUID()}@example.net`,
+      });
+      const otherUser = await databaseBuilder.factory.buildUser({
+        role: USER_ROLE.INVALID,
+        email: `other-${crypto.randomUUID()}@example.net`,
+      });
       const journey = await databaseBuilder.factory.buildPassengerJourney({ userId: owner.id });
       const auth = generateAuthenticatedUser(otherUser.id, otherUser.userType);
 
@@ -194,6 +200,169 @@ describe("Acceptance | Journeys | Journey routes", () => {
 
       // then
       expect(response.status).toBe(401);
+    });
+  });
+  describe("PUT /journeys/found/:id", () => {
+    describe("valid users", () => {
+      describe("success cases", () => {
+        it("should return http 201 status code if user accepts journey", async () => {
+          // given
+          const validUser = await databaseBuilder.factory.buildUser({ role: USER_ROLE.VALID });
+          const validJourney = await databaseBuilder.factory.buildCompanionJourney({ userId: validUser.id });
+
+          const foundJourney = await databaseBuilder.factory.buildFoundJourney({ companionJourneyId: validJourney.id });
+          const authorization = generateAuthenticatedUser(validUser.id, validUser.userType);
+
+          const body = { updatedStatus: true };
+
+          // when
+          const response = await request(server).put(`/api/journeys/found/${foundJourney.id}`).set("Authorization", authorization).send(body);
+
+          // then
+          expect(response.status).toBe(201);
+          const updatedFoundJourney = await knex("found_journeys").where({ id: foundJourney.id }).first();
+          expect(updatedFoundJourney.companionStatus).toBe(JOURNEY_STATUS.ACCEPTED);
+        });
+
+        it("should return http 201 status code if user refuses journey", async () => {
+          // given
+          const validUser = await databaseBuilder.factory.buildUser({ role: USER_ROLE.VALID });
+          const validJourney = await databaseBuilder.factory.buildCompanionJourney({ userId: validUser.id });
+
+          const foundJourney = await databaseBuilder.factory.buildFoundJourney({ companionJourneyId: validJourney.id });
+          const authorization = generateAuthenticatedUser(validUser.id, validUser.userType);
+
+          const body = { updatedStatus: false };
+
+          // when
+          const response = await request(server).put(`/api/journeys/found/${foundJourney.id}`).set("Authorization", authorization).send(body);
+
+          // then
+          expect(response.status).toBe(201);
+          const updatedFoundJourney = await knex("found_journeys").where({ id: foundJourney.id }).first();
+          expect(updatedFoundJourney.companionStatus).toBe(JOURNEY_STATUS.REJECTED);
+        });
+      });
+
+      describe("error cases", () => {
+        it("should throw an error if foundJourneyId param is not a number", async () => {
+          // given
+          const user = await databaseBuilder.factory.buildUser({ role: USER_ROLE.VALID });
+          const journey = await databaseBuilder.factory.buildCompanionJourney({ userId: user.id });
+          await databaseBuilder.factory.buildFoundJourney({ companionJourneyId: journey.id });
+          const authorization = generateAuthenticatedUser(user.id, user.userType);
+          const body = { updatedStatus: true };
+
+          // when
+          const response = await request(server).put("/api/journeys/found/foundJourneyId").send(body).set("Authorization", authorization);
+
+          // then
+          expect(response.status).toEqual(400);
+          expect(response.body.message).toBe("Validation failed");
+        });
+
+        it("should throw an error if updatedStatus is not a boolean", async () => {
+          // given
+          const user = await databaseBuilder.factory.buildUser({ role: USER_ROLE.VALID });
+          const journey = await databaseBuilder.factory.buildCompanionJourney({ userId: user.id });
+          const foundJourney = await databaseBuilder.factory.buildFoundJourney({ companionJourneyId: journey.id });
+          const authorization = generateAuthenticatedUser(user.id, user.userType);
+          const body = { updatedStatus: "test" };
+
+          // when
+          const response = await request(server).put(`/api/journeys/found/${foundJourney.id}`).send(body).set("Authorization", authorization);
+
+          // then
+          expect(response.status).toEqual(400);
+          expect(response.body.message).toBe("Validation failed");
+        });
+      });
+    });
+
+    describe("invalid users", () => {
+      describe("success cases", () => {
+        it("should return http 201 status code if user accepts journey", async () => {
+          // given
+          const invalidUser = await databaseBuilder.factory.buildUser({ role: USER_ROLE.INVALID });
+          const invalidJourney = await databaseBuilder.factory.buildPassengerJourney({ userId: invalidUser.id });
+
+          const foundJourney = await databaseBuilder.factory.buildFoundJourney({ passengerJourneyId: invalidJourney.id });
+          const authorization = generateAuthenticatedUser(invalidUser.id, invalidUser.userType);
+
+          const body = { updatedStatus: true };
+
+          // when
+          const response = await request(server).put(`/api/journeys/found/${foundJourney.id}`).set("Authorization", authorization).send(body);
+
+          // then
+          expect(response.status).toBe(201);
+          const updatedFoundJourney = await knex("found_journeys").where({ id: foundJourney.id }).first();
+          expect(updatedFoundJourney.passengerStatus).toBe(JOURNEY_STATUS.ACCEPTED);
+        });
+
+        it("should return http 201 status code if user refuses journey", async () => {
+          // given
+          const invalidUser = await databaseBuilder.factory.buildUser({ role: USER_ROLE.INVALID });
+          const invalidJourney = await databaseBuilder.factory.buildPassengerJourney({ userId: invalidUser.id });
+
+          const foundJourney = await databaseBuilder.factory.buildFoundJourney({ passengerJourneyId: invalidJourney.id });
+          const authorization = generateAuthenticatedUser(invalidUser.id, invalidUser.userType);
+
+          const body = { updatedStatus: false };
+
+          // when
+          const response = await request(server).put(`/api/journeys/found/${foundJourney.id}`).set("Authorization", authorization).send(body);
+
+          // then
+          expect(response.status).toBe(201);
+          const updatedFoundJourney = await knex("found_journeys").where({ id: foundJourney.id }).first();
+          expect(updatedFoundJourney.passengerStatus).toBe(JOURNEY_STATUS.REJECTED);
+        });
+      });
+
+      describe("error cases", () => {
+        it("should throw an error if foundJourneyId param is not a number", async () => {
+          // given
+          const user = await databaseBuilder.factory.buildUser({ role: USER_ROLE.INVALID });
+          const journey = await databaseBuilder.factory.buildPassengerJourney({ userId: user.id });
+          await databaseBuilder.factory.buildFoundJourney({ passengerJourneyId: journey.id });
+          const authorization = generateAuthenticatedUser(user.id, user.userType);
+          const body = { updatedStatus: true };
+
+          // when
+          const response = await request(server).put("/api/journeys/found/foundJourneyId").send(body).set("Authorization", authorization);
+
+          // then
+          expect(response.status).toEqual(400);
+          expect(response.body.message).toBe("Validation failed");
+        });
+
+        it("should throw an error if updatedStatus is not a boolean", async () => {
+          // given
+          const user = await databaseBuilder.factory.buildUser({ role: USER_ROLE.INVALID });
+          const journey = await databaseBuilder.factory.buildPassengerJourney({ userId: user.id });
+          const foundJourney = await databaseBuilder.factory.buildFoundJourney({ passengerJourneyId: journey.id });
+          const authorization = generateAuthenticatedUser(user.id, user.userType);
+          const body = { updatedStatus: "test" };
+
+          // when
+          const response = await request(server).put(`/api/journeys/found/${foundJourney.id}`).send(body).set("Authorization", authorization);
+
+          // then
+          expect(response.status).toEqual(400);
+          expect(response.body.message).toBe("Validation failed");
+        });
+      });
+    });
+
+    describe("general cases", () => {
+      it("should return 401 error if token is missing", async () => {
+        // when
+        const response = await request(server).put("/api/journeys/found/123");
+
+        // then
+        expect(response.status).toBe(401);
+      });
     });
   });
 });

--- a/api/tests/journeys/integration/repositories/found-journeys-repository.test.js
+++ b/api/tests/journeys/integration/repositories/found-journeys-repository.test.js
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import databaseBuilder from "../../../../db/database-builder/index.js";
+import { knex } from "../../../../db/knex-database-connection.js";
+import * as foundJouroneysRepository from "../../../../src/journeys/repositories/found-journeys-repository.js";
+import { JOURNEY_STATUS } from "../../../../src/shared/constants.js";
+
+describe("Integration | Journeys | Repositories | Found journeys repository", () => {
+  describe("#foundJourneyByFoundJourneyId", () => {
+    it("should return the found journey corresponding to id", async () => {
+      // given
+      const createdFoundJourney = await databaseBuilder.factory.buildFoundJourney();
+
+      // when
+      const foundFoundJourney = await foundJouroneysRepository.findFoundJourneyByFoundJourneyId(createdFoundJourney.id);
+
+      // then
+      expect(foundFoundJourney).toBeDefined();
+      expect(foundFoundJourney).toEqual(createdFoundJourney);
+    });
+
+    it("should return null if no found journey is found", async () => {
+      // given
+      const foundJourneyId = 123;
+
+      // when
+      const foundFoundJourney = await foundJouroneysRepository.findFoundJourneyByFoundJourneyId(foundJourneyId);
+
+      // then
+      expect(foundFoundJourney).toBeNull();
+    });
+  });
+
+  describe("#updateFoundJourneyCompanionStatusByFoundJourneyId", () => {
+    it("should update the found journey status", async () => {
+      // given
+      const createdFoundJourney = await databaseBuilder.factory.buildFoundJourney({ companionStatus: JOURNEY_STATUS.WAITING });
+
+      // when
+      await foundJouroneysRepository.updateFoundJourneyCompanionStatusByFoundJourneyId({ foundJourneyId: createdFoundJourney.id, status: JOURNEY_STATUS.ACCEPTED });
+
+      // when
+      const updatedFoundJourney = await knex("found_journeys").where({ id: createdFoundJourney.id }).first();
+      expect(updatedFoundJourney.companionStatus).toBe(JOURNEY_STATUS.ACCEPTED);
+    });
+  });
+
+  describe("#updateFoundJourneyPassengerStatusByFoundJourneyId", () => {
+    it("should update the found journey status", async () => {
+      // given
+      const createdFoundJourney = await databaseBuilder.factory.buildFoundJourney({ passengerStatus: JOURNEY_STATUS.WAITING });
+
+      // when
+      await foundJouroneysRepository.updateFoundJourneyPassengerStatusByFoundJourneyId({ foundJourneyId: createdFoundJourney.id, status: JOURNEY_STATUS.ACCEPTED });
+
+      // when
+      const updatedFoundJourney = await knex("found_journeys").where({ id: createdFoundJourney.id }).first();
+      expect(updatedFoundJourney.passengerStatus).toBe(JOURNEY_STATUS.ACCEPTED);
+    });
+  });
+});

--- a/api/tests/journeys/integration/usecases/accept-found-journey-companion-status-usecase.test.js
+++ b/api/tests/journeys/integration/usecases/accept-found-journey-companion-status-usecase.test.js
@@ -1,0 +1,100 @@
+import { describe, expect, it, suite } from "vitest";
+
+import databaseBuilder from "../../../../db/database-builder/index.js";
+import { knex } from "../../../../db/knex-database-connection.js";
+import {
+  AlreadyAccepted, AlreadyCancelled,
+  AlreadyRejected,
+  JourneyIsNotOfThisUser,
+  JourneyNotFound,
+} from "../../../../src/journeys/errors.js";
+import usecases from "../../../../src/journeys/usecases/index.js";
+import { JOURNEY_STATUS } from "../../../../src/shared/constants.js";
+
+describe("Integration | Journeys | Usecases | Accept found journey companion status", () => {
+  describe("success case", () => {
+    it(`should update status of found journey with ${JOURNEY_STATUS.ACCEPTED}`, async () => {
+      // given
+      const user = await databaseBuilder.factory.buildUser();
+      const journey = await databaseBuilder.factory.buildCompanionJourney({ userId: user.id });
+      const foundJourney = await databaseBuilder.factory.buildFoundJourney({ companionJourneyId: journey.id, companionStatus: JOURNEY_STATUS.WAITING });
+
+      // when
+      await usecases.acceptFoundJourneyCompanionStatusUsecase({ userId: user.id, foundJourneyId: foundJourney.id });
+
+      // then
+      const updatedFoundJourney = await knex("found_journeys").where({ id: foundJourney.id }).first();
+      expect(updatedFoundJourney.companionStatus).toBe(JOURNEY_STATUS.ACCEPTED);
+    });
+  });
+
+  describe("error cases", () => {
+    it("should throw a not found error", async () => {
+      // given
+      const foundJourneyId = 123;
+
+      // when
+      const result = usecases.acceptFoundJourneyCompanionStatusUsecase({ foundJourneyId });
+
+      // then
+      await expect(result).rejects.toThrow(JourneyNotFound);
+    });
+
+    it("should throw an error if journey is not of the user", async () => {
+      // given
+      const user = await databaseBuilder.factory.buildUser();
+      const journey = await databaseBuilder.factory.buildCompanionJourney({ userId: user.id });
+      const foundJourney = await databaseBuilder.factory.buildFoundJourney({ companionJourneyId: journey.id });
+      const fakeUserId = 123;
+
+      // when
+      const result = usecases.acceptFoundJourneyCompanionStatusUsecase({ userId: fakeUserId, foundJourneyId: foundJourney.id });
+
+      // then
+      await expect(result).rejects.toThrow(JourneyIsNotOfThisUser);
+      const updatedFoundJourney = await knex("found_journeys").where({ id: foundJourney.id }).first();
+      expect(updatedFoundJourney.companionStatus).toBe(JOURNEY_STATUS.WAITING);
+    });
+
+    suite("when a found journey status is already accepted or rejected", () => {
+      it("should throw an error if journey is already accepted", async () => {
+        // given
+        const user = await databaseBuilder.factory.buildUser();
+        const journey = await databaseBuilder.factory.buildCompanionJourney({ userId: user.id });
+        const foundJourney = await databaseBuilder.factory.buildFoundJourney({ companionJourneyId: journey.id, companionStatus: JOURNEY_STATUS.ACCEPTED });
+
+        // when
+        const result = usecases.acceptFoundJourneyCompanionStatusUsecase({ userId: user.id, foundJourneyId: foundJourney.id });
+
+        // then
+        await expect(result).rejects.toThrow(AlreadyAccepted);
+      });
+
+      it("should throw an error if journey is already rejected", async () => {
+        // given
+        const user = await databaseBuilder.factory.buildUser();
+        const journey = await databaseBuilder.factory.buildCompanionJourney({ userId: user.id });
+        const foundJourney = await databaseBuilder.factory.buildFoundJourney({ companionJourneyId: journey.id, companionStatus: JOURNEY_STATUS.REJECTED });
+
+        // when
+        const result = usecases.acceptFoundJourneyCompanionStatusUsecase({ userId: user.id, foundJourneyId: foundJourney.id });
+
+        // then
+        await expect(result).rejects.toThrow(AlreadyRejected);
+      });
+
+      it("should throw an error if journey is already cancelled", async () => {
+        // given
+        const user = await databaseBuilder.factory.buildUser();
+        const journey = await databaseBuilder.factory.buildCompanionJourney({ userId: user.id });
+        const foundJourney = await databaseBuilder.factory.buildFoundJourney({ companionJourneyId: journey.id, companionStatus: JOURNEY_STATUS.CANCELLED });
+
+        // when
+        const result = usecases.acceptFoundJourneyCompanionStatusUsecase({ userId: user.id, foundJourneyId: foundJourney.id });
+
+        // then
+        await expect(result).rejects.toThrow(AlreadyCancelled);
+      });
+    });
+  });
+});

--- a/api/tests/journeys/integration/usecases/accept-found-journey-passenger-status-usecase.test.js
+++ b/api/tests/journeys/integration/usecases/accept-found-journey-passenger-status-usecase.test.js
@@ -1,0 +1,100 @@
+import { describe, expect, it, suite } from "vitest";
+
+import databaseBuilder from "../../../../db/database-builder/index.js";
+import { knex } from "../../../../db/knex-database-connection.js";
+import {
+  AlreadyAccepted, AlreadyCancelled,
+  AlreadyRejected,
+  JourneyIsNotOfThisUser,
+  JourneyNotFound,
+} from "../../../../src/journeys/errors.js";
+import usecases from "../../../../src/journeys/usecases/index.js";
+import { JOURNEY_STATUS } from "../../../../src/shared/constants.js";
+
+describe("Integration | Journeys | Usecases | Accept found journey passenger status", () => {
+  describe("success case", () => {
+    it(`should update status of found journey with ${JOURNEY_STATUS.ACCEPTED}`, async () => {
+      // given
+      const user = await databaseBuilder.factory.buildUser();
+      const journey = await databaseBuilder.factory.buildPassengerJourney({ userId: user.id });
+      const foundJourney = await databaseBuilder.factory.buildFoundJourney({ passengerJourneyId: journey.id, passengerStatus: JOURNEY_STATUS.WAITING });
+
+      // when
+      await usecases.acceptFoundJourneyPassengerStatusUsecase({ userId: user.id, foundJourneyId: foundJourney.id });
+
+      // then
+      const updatedFoundJourney = await knex("found_journeys").where({ id: foundJourney.id }).first();
+      expect(updatedFoundJourney.passengerStatus).toBe(JOURNEY_STATUS.ACCEPTED);
+    });
+  });
+
+  describe("error cases", () => {
+    it("should throw a not found journey error", async () => {
+      // given
+      const foundJourneyId = 123;
+
+      // when
+      const result = usecases.acceptFoundJourneyPassengerStatusUsecase({ foundJourneyId });
+
+      // then
+      await expect(result).rejects.toThrow(JourneyNotFound);
+    });
+
+    it("should throw an error if journey is not of user", async () => {
+      // given
+      const user = await databaseBuilder.factory.buildUser();
+      const journey = await databaseBuilder.factory.buildPassengerJourney({ userId: user.id });
+      const foundJourney = await databaseBuilder.factory.buildFoundJourney({ passengerJourneyId: journey.id });
+      const fakeUserId = 123;
+
+      // when
+      const result = usecases.acceptFoundJourneyPassengerStatusUsecase({ userId: fakeUserId, foundJourneyId: foundJourney.id });
+
+      // then
+      await expect(result).rejects.toThrow(JourneyIsNotOfThisUser);
+      const updatedFoundJourney = await knex("found_journeys").where({ id: foundJourney.id }).first();
+      expect(updatedFoundJourney.passengerStatus).toBe(JOURNEY_STATUS.WAITING);
+    });
+
+    suite("when a found journey status is already accepted or rejected", () => {
+      it("should throw an error if journey is already accepted", async () => {
+        // given
+        const user = await databaseBuilder.factory.buildUser();
+        const journey = await databaseBuilder.factory.buildPassengerJourney({ userId: user.id });
+        const foundJourney = await databaseBuilder.factory.buildFoundJourney({ passengerJourneyId: journey.id, passengerStatus: JOURNEY_STATUS.ACCEPTED });
+
+        // when
+        const result = usecases.acceptFoundJourneyPassengerStatusUsecase({ userId: user.id, foundJourneyId: foundJourney.id });
+
+        // then
+        await expect(result).rejects.toThrow(AlreadyAccepted);
+      });
+
+      it("should throw an error if journey is already rejected", async () => {
+        // given
+        const user = await databaseBuilder.factory.buildUser();
+        const journey = await databaseBuilder.factory.buildPassengerJourney({ userId: user.id });
+        const foundJourney = await databaseBuilder.factory.buildFoundJourney({ passengerJourneyId: journey.id, passengerStatus: JOURNEY_STATUS.REJECTED });
+
+        // when
+        const result = usecases.acceptFoundJourneyPassengerStatusUsecase({ userId: user.id, foundJourneyId: foundJourney.id });
+
+        // then
+        await expect(result).rejects.toThrow(AlreadyRejected);
+      });
+
+      it("should throw an error if journey is already cancelled", async () => {
+        // given
+        const user = await databaseBuilder.factory.buildUser();
+        const journey = await databaseBuilder.factory.buildPassengerJourney({ userId: user.id });
+        const foundJourney = await databaseBuilder.factory.buildFoundJourney({ passengerJourneyId: journey.id, passengerStatus: JOURNEY_STATUS.CANCELLED });
+
+        // when
+        const result = usecases.acceptFoundJourneyPassengerStatusUsecase({ userId: user.id, foundJourneyId: foundJourney.id });
+
+        // then
+        await expect(result).rejects.toThrow(AlreadyCancelled);
+      });
+    });
+  });
+});

--- a/api/tests/journeys/integration/usecases/cancel-found-journey-companion-status-usecase.test.js
+++ b/api/tests/journeys/integration/usecases/cancel-found-journey-companion-status-usecase.test.js
@@ -1,0 +1,100 @@
+import { describe, expect, it, suite } from "vitest";
+
+import databaseBuilder from "../../../../db/database-builder/index.js";
+import { knex } from "../../../../db/knex-database-connection.js";
+import {
+  AlreadyAccepted, AlreadyCancelled,
+  AlreadyRejected,
+  JourneyIsNotOfThisUser,
+  JourneyNotFound,
+} from "../../../../src/journeys/errors.js";
+import usecases from "../../../../src/journeys/usecases/index.js";
+import { JOURNEY_STATUS } from "../../../../src/shared/constants.js";
+
+describe("Integration | Journeys | Usecases | Cancel found journey companion status", () => {
+  describe("success case", () => {
+    it(`should update status of found journey with ${JOURNEY_STATUS.CANCELLED}`, async () => {
+      // given
+      const user = await databaseBuilder.factory.buildUser();
+      const journey = await databaseBuilder.factory.buildCompanionJourney({ userId: user.id });
+      const foundJourney = await databaseBuilder.factory.buildFoundJourney({ companionJourneyId: journey.id, companionStatus: JOURNEY_STATUS.WAITING });
+
+      // when
+      await usecases.cancelFoundJourneyCompanionStatusUsecase({ userId: user.id, foundJourneyId: foundJourney.id });
+
+      // then
+      const updatedFoundJourney = await knex("found_journeys").where({ id: foundJourney.id }).first();
+      expect(updatedFoundJourney.companionStatus).toBe(JOURNEY_STATUS.CANCELLED);
+    });
+  });
+
+  describe("error cases", () => {
+    it("should throw a journey not found error", async () => {
+      // given
+      const foundJourneyId = 123;
+
+      // when
+      const result = usecases.cancelFoundJourneyCompanionStatusUsecase({ foundJourneyId });
+
+      // then
+      await expect(result).rejects.toThrow(JourneyNotFound);
+    });
+
+    it("should throw an error if journey is not of user", async () => {
+      // given
+      const user = await databaseBuilder.factory.buildUser();
+      const journey = await databaseBuilder.factory.buildCompanionJourney({ userId: user.id });
+      const foundJourney = await databaseBuilder.factory.buildFoundJourney({ companionJourneyId: journey.id });
+      const fakeUserId = 123;
+
+      // when
+      const result = usecases.cancelFoundJourneyCompanionStatusUsecase({ userId: fakeUserId, foundJourneyId: foundJourney.id });
+
+      // then
+      await expect(result).rejects.toThrow(JourneyIsNotOfThisUser);
+      const updatedFoundJourney = await knex("found_journeys").where({ id: foundJourney.id }).first();
+      expect(updatedFoundJourney.companionStatus).toBe(JOURNEY_STATUS.WAITING);
+    });
+
+    suite("when a found journey status is already accepted or rejected", () => {
+      it("should throw an error if journey is already accepted", async () => {
+        // given
+        const user = await databaseBuilder.factory.buildUser();
+        const journey = await databaseBuilder.factory.buildCompanionJourney({ userId: user.id });
+        const foundJourney = await databaseBuilder.factory.buildFoundJourney({ companionJourneyId: journey.id, companionStatus: JOURNEY_STATUS.ACCEPTED });
+
+        // when
+        const result = usecases.cancelFoundJourneyCompanionStatusUsecase({ userId: user.id, foundJourneyId: foundJourney.id });
+
+        // then
+        await expect(result).rejects.toThrow(AlreadyAccepted);
+      });
+
+      it("should throw an error if journey is already rejected", async () => {
+        // given
+        const user = await databaseBuilder.factory.buildUser();
+        const journey = await databaseBuilder.factory.buildCompanionJourney({ userId: user.id });
+        const foundJourney = await databaseBuilder.factory.buildFoundJourney({ companionJourneyId: journey.id, companionStatus: JOURNEY_STATUS.REJECTED });
+
+        // when
+        const result = usecases.cancelFoundJourneyCompanionStatusUsecase({ userId: user.id, foundJourneyId: foundJourney.id });
+
+        // then
+        await expect(result).rejects.toThrow(AlreadyRejected);
+      });
+
+      it("should throw an error if journey is already cancelled", async () => {
+        // given
+        const user = await databaseBuilder.factory.buildUser();
+        const journey = await databaseBuilder.factory.buildCompanionJourney({ userId: user.id });
+        const foundJourney = await databaseBuilder.factory.buildFoundJourney({ companionJourneyId: journey.id, companionStatus: JOURNEY_STATUS.CANCELLED });
+
+        // when
+        const result = usecases.cancelFoundJourneyCompanionStatusUsecase({ userId: user.id, foundJourneyId: foundJourney.id });
+
+        // then
+        await expect(result).rejects.toThrow(AlreadyCancelled);
+      });
+    });
+  });
+});

--- a/api/tests/journeys/integration/usecases/cancel-found-journey-passenger-status-usecase.test.js
+++ b/api/tests/journeys/integration/usecases/cancel-found-journey-passenger-status-usecase.test.js
@@ -1,0 +1,100 @@
+import { describe, expect, it, suite } from "vitest";
+
+import databaseBuilder from "../../../../db/database-builder/index.js";
+import { knex } from "../../../../db/knex-database-connection.js";
+import {
+  AlreadyAccepted, AlreadyCancelled,
+  AlreadyRejected,
+  JourneyIsNotOfThisUser,
+  JourneyNotFound,
+} from "../../../../src/journeys/errors.js";
+import usecases from "../../../../src/journeys/usecases/index.js";
+import { JOURNEY_STATUS } from "../../../../src/shared/constants.js";
+
+describe("Integration | Journeys | Usecases | Cancel found journey passenger status", () => {
+  describe("success case", () => {
+    it(`should update status of found journey with ${JOURNEY_STATUS.CANCELLED}`, async () => {
+      // given
+      const user = await databaseBuilder.factory.buildUser();
+      const journey = await databaseBuilder.factory.buildPassengerJourney({ userId: user.id });
+      const foundJourney = await databaseBuilder.factory.buildFoundJourney({ passengerJourneyId: journey.id, passengerStatus: JOURNEY_STATUS.WAITING });
+
+      // when
+      await usecases.cancelFoundJourneyPassengerStatusUsecase({ userId: user.id, foundJourneyId: foundJourney.id });
+
+      // then
+      const updatedFoundJourney = await knex("found_journeys").where({ id: foundJourney.id }).first();
+      expect(updatedFoundJourney.passengerStatus).toBe(JOURNEY_STATUS.CANCELLED);
+    });
+  });
+
+  describe("error cases", () => {
+    it("should throw an error for not found journey", async () => {
+      // given
+      const foundJourneyId = 123;
+
+      // when
+      const result = usecases.cancelFoundJourneyPassengerStatusUsecase({ foundJourneyId });
+
+      // then
+      await expect(result).rejects.toThrow(JourneyNotFound);
+    });
+
+    it("should throw an error if journey is not of user", async () => {
+      // given
+      const user = await databaseBuilder.factory.buildUser();
+      const journey = await databaseBuilder.factory.buildPassengerJourney({ userId: user.id });
+      const foundJourney = await databaseBuilder.factory.buildFoundJourney({ passengerJourneyId: journey.id });
+      const fakeUserId = 123;
+
+      // when
+      const result = usecases.cancelFoundJourneyPassengerStatusUsecase({ userId: fakeUserId, foundJourneyId: foundJourney.id });
+
+      // then
+      await expect(result).rejects.toThrow(JourneyIsNotOfThisUser);
+      const updatedFoundJourney = await knex("found_journeys").where({ id: foundJourney.id }).first();
+      expect(updatedFoundJourney.passengerStatus).toBe(JOURNEY_STATUS.WAITING);
+    });
+
+    suite("when a found journey status is already accepted or rejected", () => {
+      it("should throw an error if journey is already accepted", async () => {
+        // given
+        const user = await databaseBuilder.factory.buildUser();
+        const journey = await databaseBuilder.factory.buildPassengerJourney({ userId: user.id });
+        const foundJourney = await databaseBuilder.factory.buildFoundJourney({ passengerJourneyId: journey.id, passengerStatus: JOURNEY_STATUS.ACCEPTED });
+
+        // when
+        const result = usecases.cancelFoundJourneyPassengerStatusUsecase({ userId: user.id, foundJourneyId: foundJourney.id });
+
+        // then
+        await expect(result).rejects.toThrow(AlreadyAccepted);
+      });
+
+      it("should throw an error if journey is already rejected", async () => {
+        // given
+        const user = await databaseBuilder.factory.buildUser();
+        const journey = await databaseBuilder.factory.buildPassengerJourney({ userId: user.id });
+        const foundJourney = await databaseBuilder.factory.buildFoundJourney({ passengerJourneyId: journey.id, passengerStatus: JOURNEY_STATUS.REJECTED });
+
+        // when
+        const result = usecases.cancelFoundJourneyPassengerStatusUsecase({ userId: user.id, foundJourneyId: foundJourney.id });
+
+        // then
+        await expect(result).rejects.toThrow(AlreadyRejected);
+      });
+
+      it("should throw an error if journey is already cancelled", async () => {
+        // given
+        const user = await databaseBuilder.factory.buildUser();
+        const journey = await databaseBuilder.factory.buildPassengerJourney({ userId: user.id });
+        const foundJourney = await databaseBuilder.factory.buildFoundJourney({ passengerJourneyId: journey.id, passengerStatus: JOURNEY_STATUS.CANCELLED });
+
+        // when
+        const result = usecases.cancelFoundJourneyPassengerStatusUsecase({ userId: user.id, foundJourneyId: foundJourney.id });
+
+        // then
+        await expect(result).rejects.toThrow(AlreadyCancelled);
+      });
+    });
+  });
+});

--- a/api/tests/journeys/integration/usecases/reject-found-journey-companion-status-usecase.test.js
+++ b/api/tests/journeys/integration/usecases/reject-found-journey-companion-status-usecase.test.js
@@ -1,0 +1,100 @@
+import { describe, expect, it, suite } from "vitest";
+
+import databaseBuilder from "../../../../db/database-builder/index.js";
+import { knex } from "../../../../db/knex-database-connection.js";
+import {
+  AlreadyAccepted, AlreadyCancelled,
+  AlreadyRejected,
+  JourneyIsNotOfThisUser,
+  JourneyNotFound,
+} from "../../../../src/journeys/errors.js";
+import usecases from "../../../../src/journeys/usecases/index.js";
+import { JOURNEY_STATUS } from "../../../../src/shared/constants.js";
+
+describe("Integration | Journeys | Usecases | Reject found journey companion status", () => {
+  describe("success case", () => {
+    it(`should update status of found journey with ${JOURNEY_STATUS.REJECTED}`, async () => {
+      // given
+      const user = await databaseBuilder.factory.buildUser();
+      const journey = await databaseBuilder.factory.buildCompanionJourney({ userId: user.id });
+      const foundJourney = await databaseBuilder.factory.buildFoundJourney({ companionJourneyId: journey.id, companionStatus: JOURNEY_STATUS.WAITING });
+
+      // when
+      await usecases.rejectFoundJourneyCompanionStatusUsecase({ userId: user.id, foundJourneyId: foundJourney.id });
+
+      // then
+      const updatedFoundJourney = await knex("found_journeys").where({ id: foundJourney.id }).first();
+      expect(updatedFoundJourney.companionStatus).toBe(JOURNEY_STATUS.REJECTED);
+    });
+  });
+
+  describe("error cases", () => {
+    it("should throw an error for journey not found", async () => {
+      // given
+      const foundJourneyId = 123;
+
+      // when
+      const result = usecases.rejectFoundJourneyCompanionStatusUsecase({ foundJourneyId });
+
+      // then
+      await expect(result).rejects.toThrow(JourneyNotFound);
+    });
+
+    it("should throw an error if journey is not of user", async () => {
+      // given
+      const user = await databaseBuilder.factory.buildUser();
+      const journey = await databaseBuilder.factory.buildCompanionJourney({ userId: user.id });
+      const foundJourney = await databaseBuilder.factory.buildFoundJourney({ companionJourneyId: journey.id });
+      const fakeUserId = 123;
+
+      // when
+      const result = usecases.rejectFoundJourneyCompanionStatusUsecase({ userId: fakeUserId, foundJourneyId: foundJourney.id });
+
+      // then
+      await expect(result).rejects.toThrow(JourneyIsNotOfThisUser);
+      const updatedFoundJourney = await knex("found_journeys").where({ id: foundJourney.id }).first();
+      expect(updatedFoundJourney.companionStatus).toBe(JOURNEY_STATUS.WAITING);
+    });
+
+    suite("when a found journey status is already accepted or rejected", () => {
+      it("should throw an error if journey is already accepted", async () => {
+        // given
+        const user = await databaseBuilder.factory.buildUser();
+        const journey = await databaseBuilder.factory.buildCompanionJourney({ userId: user.id });
+        const foundJourney = await databaseBuilder.factory.buildFoundJourney({ companionJourneyId: journey.id, companionStatus: JOURNEY_STATUS.ACCEPTED });
+
+        // when
+        const result = usecases.rejectFoundJourneyCompanionStatusUsecase({ userId: user.id, foundJourneyId: foundJourney.id });
+
+        // then
+        await expect(result).rejects.toThrow(AlreadyAccepted);
+      });
+
+      it("should throw an error if journey is already rejected", async () => {
+        // given
+        const user = await databaseBuilder.factory.buildUser();
+        const journey = await databaseBuilder.factory.buildCompanionJourney({ userId: user.id });
+        const foundJourney = await databaseBuilder.factory.buildFoundJourney({ companionJourneyId: journey.id, companionStatus: JOURNEY_STATUS.REJECTED });
+
+        // when
+        const result = usecases.rejectFoundJourneyCompanionStatusUsecase({ userId: user.id, foundJourneyId: foundJourney.id });
+
+        // then
+        await expect(result).rejects.toThrow(AlreadyRejected);
+      });
+
+      it("should throw an error if journey is already cancelled", async () => {
+        // given
+        const user = await databaseBuilder.factory.buildUser();
+        const journey = await databaseBuilder.factory.buildCompanionJourney({ userId: user.id });
+        const foundJourney = await databaseBuilder.factory.buildFoundJourney({ companionJourneyId: journey.id, companionStatus: JOURNEY_STATUS.CANCELLED });
+
+        // when
+        const result = usecases.rejectFoundJourneyCompanionStatusUsecase({ userId: user.id, foundJourneyId: foundJourney.id });
+
+        // then
+        await expect(result).rejects.toThrow(AlreadyCancelled);
+      });
+    });
+  });
+});

--- a/api/tests/journeys/integration/usecases/reject-found-journey-passenger-status-usecase.test.js
+++ b/api/tests/journeys/integration/usecases/reject-found-journey-passenger-status-usecase.test.js
@@ -1,0 +1,100 @@
+import { describe, expect, it, suite } from "vitest";
+
+import databaseBuilder from "../../../../db/database-builder/index.js";
+import { knex } from "../../../../db/knex-database-connection.js";
+import {
+  AlreadyAccepted, AlreadyCancelled,
+  AlreadyRejected,
+  JourneyIsNotOfThisUser,
+  JourneyNotFound,
+} from "../../../../src/journeys/errors.js";
+import usecases from "../../../../src/journeys/usecases/index.js";
+import { JOURNEY_STATUS } from "../../../../src/shared/constants.js";
+
+describe("Integration | Journeys | Usecases | Reject found journey passenger status", () => {
+  describe("success case", () => {
+    it(`should update status of found journey with ${JOURNEY_STATUS.REJECTED}`, async () => {
+      // given
+      const user = await databaseBuilder.factory.buildUser();
+      const journey = await databaseBuilder.factory.buildPassengerJourney({ userId: user.id });
+      const foundJourney = await databaseBuilder.factory.buildFoundJourney({ passengerJourneyId: journey.id, passengerStatus: JOURNEY_STATUS.WAITING });
+
+      // when
+      await usecases.rejectFoundJourneyPassengerStatusUsecase({ userId: user.id, foundJourneyId: foundJourney.id });
+
+      // then
+      const updatedFoundJourney = await knex("found_journeys").where({ id: foundJourney.id }).first();
+      expect(updatedFoundJourney.passengerStatus).toBe(JOURNEY_STATUS.REJECTED);
+    });
+  });
+
+  describe("error cases", () => {
+    it("should throw a journey not found error", async () => {
+      // given
+      const foundJourneyId = 123;
+
+      // when
+      const result = usecases.rejectFoundJourneyPassengerStatusUsecase({ foundJourneyId });
+
+      // then
+      await expect(result).rejects.toThrow(JourneyNotFound);
+    });
+
+    it("should throw an error if journey is not of user", async () => {
+      // given
+      const user = await databaseBuilder.factory.buildUser();
+      const journey = await databaseBuilder.factory.buildPassengerJourney({ userId: user.id });
+      const foundJourney = await databaseBuilder.factory.buildFoundJourney({ passengerJourneyId: journey.id });
+      const fakeUserId = 123;
+
+      // when
+      const result = usecases.rejectFoundJourneyPassengerStatusUsecase({ userId: fakeUserId, foundJourneyId: foundJourney.id });
+
+      // then
+      await expect(result).rejects.toThrow(JourneyIsNotOfThisUser);
+      const updatedFoundJourney = await knex("found_journeys").where({ id: foundJourney.id }).first();
+      expect(updatedFoundJourney.passengerStatus).toBe(JOURNEY_STATUS.WAITING);
+    });
+
+    suite("when a found journey status is already accepted rejected", () => {
+      it("should throw an error if journey is already accepted", async () => {
+        // given
+        const user = await databaseBuilder.factory.buildUser();
+        const journey = await databaseBuilder.factory.buildPassengerJourney({ userId: user.id });
+        const foundJourney = await databaseBuilder.factory.buildFoundJourney({ passengerJourneyId: journey.id, passengerStatus: JOURNEY_STATUS.ACCEPTED });
+
+        // when
+        const result = usecases.rejectFoundJourneyPassengerStatusUsecase({ userId: user.id, foundJourneyId: foundJourney.id });
+
+        // then
+        await expect(result).rejects.toThrow(AlreadyAccepted);
+      });
+
+      it("should throw an error if journey is already rejected", async () => {
+        // given
+        const user = await databaseBuilder.factory.buildUser();
+        const journey = await databaseBuilder.factory.buildPassengerJourney({ userId: user.id });
+        const foundJourney = await databaseBuilder.factory.buildFoundJourney({ passengerJourneyId: journey.id, passengerStatus: JOURNEY_STATUS.REJECTED });
+
+        // when
+        const result = usecases.rejectFoundJourneyPassengerStatusUsecase({ userId: user.id, foundJourneyId: foundJourney.id });
+
+        // then
+        await expect(result).rejects.toThrow(AlreadyRejected);
+      });
+
+      it("should throw an error if journey is already cancelled", async () => {
+        // given
+        const user = await databaseBuilder.factory.buildUser();
+        const journey = await databaseBuilder.factory.buildPassengerJourney({ userId: user.id });
+        const foundJourney = await databaseBuilder.factory.buildFoundJourney({ passengerJourneyId: journey.id, passengerStatus: JOURNEY_STATUS.CANCELLED });
+
+        // when
+        const result = usecases.rejectFoundJourneyPassengerStatusUsecase({ userId: user.id, foundJourneyId: foundJourney.id });
+
+        // then
+        await expect(result).rejects.toThrow(AlreadyCancelled);
+      });
+    });
+  });
+});

--- a/api/tests/journeys/unit/api/controllers/update-found-journey-status-controller.test.js
+++ b/api/tests/journeys/unit/api/controllers/update-found-journey-status-controller.test.js
@@ -1,0 +1,295 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { updateFoundJourneyStatusController } from "../../../../../src/journeys/api/controllers/update-found-journey-status-controller.js";
+import { UserHasNoRole } from "../../../../../src/journeys/errors.js";
+import { USER_ROLE } from "../../../../../src/shared/constants.js";
+
+describe("Unit | Journeys | Api | Controller | Update found journey status controller", () => {
+  let res, next, acceptCompanionUsecase, rejectCompanionUsecase, acceptPassengerUsecase, rejectPassengerUsecase, findUser;
+  beforeEach(() => {
+    res = {
+      status: vi.fn().mockReturnThis(),
+      send: vi.fn(),
+    };
+    next = vi.fn();
+    acceptCompanionUsecase = vi.fn();
+    rejectCompanionUsecase = vi.fn();
+    acceptPassengerUsecase = vi.fn();
+    rejectPassengerUsecase = vi.fn();
+    findUser = vi.fn();
+  });
+  describe("valid user", () => {
+    describe("Success cases", () => {
+      it("should accept journey and call 201 http status code", async () => {
+        // given
+        const req = {
+          auth: {
+            userId: 123,
+          },
+          params: {
+            foundJourneyId: 234,
+          },
+          body: {
+            updatedStatus: true,
+          },
+        };
+        findUser.mockResolvedValue({ id: 123, role: USER_ROLE.VALID });
+
+        // when
+        await updateFoundJourneyStatusController(
+          req,
+          res,
+          next,
+          acceptCompanionUsecase,
+          rejectCompanionUsecase,
+          acceptPassengerUsecase,
+          rejectPassengerUsecase,
+          findUser,
+        );
+
+        // then
+        expect(res.status).toHaveBeenCalledWith(201);
+        expect(res.send).toHaveBeenCalled();
+        expect(acceptCompanionUsecase).toHaveBeenCalledWith({ userId: 123, foundJourneyId: 234 });
+        expect(rejectCompanionUsecase).not.toHaveBeenCalled();
+        expect(acceptPassengerUsecase).not.toHaveBeenCalled();
+        expect(rejectPassengerUsecase).not.toHaveBeenCalled();
+        expect(rejectPassengerUsecase).not.toHaveBeenCalled();
+      });
+
+      it("should reject journey and call 201 http status code", async () => {
+        // given
+        const req = {
+          auth: {
+            userId: 123,
+          },
+          params: {
+            foundJourneyId: 234,
+          },
+          body: {
+            updatedStatus: false,
+          },
+        };
+        findUser.mockResolvedValue({ id: 123, role: USER_ROLE.VALID });
+
+        // when
+        await updateFoundJourneyStatusController(
+          req,
+          res,
+          next,
+          acceptCompanionUsecase,
+          rejectCompanionUsecase,
+          acceptPassengerUsecase,
+          rejectPassengerUsecase,
+          findUser,
+        );
+
+        // then
+        expect(res.status).toHaveBeenCalledWith(201);
+        expect(res.send).toHaveBeenCalled();
+        expect(acceptCompanionUsecase).not.toHaveBeenCalled();
+        expect(rejectCompanionUsecase).toHaveBeenCalledWith({ userId: 123, foundJourneyId: 234 });
+        expect(acceptPassengerUsecase).not.toHaveBeenCalled();
+        expect(rejectPassengerUsecase).not.toHaveBeenCalled();
+        expect(rejectPassengerUsecase).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("error cases", () => {
+      it("should throw an error and call next middleware", async () => {
+        // given
+        const req = {
+          auth: {
+            userId: 123,
+          },
+          params: {
+            foundJourneyId: 234,
+          },
+          body: {
+            updatedStatus: true,
+          },
+        };
+        findUser.mockResolvedValue({ id: 123, role: USER_ROLE.VALID });
+        acceptCompanionUsecase.mockRejectedValue(new Error("Error message"));
+
+        // when
+        await updateFoundJourneyStatusController(
+          req,
+          res,
+          next,
+          acceptCompanionUsecase,
+          rejectCompanionUsecase,
+          acceptPassengerUsecase,
+          rejectPassengerUsecase,
+          findUser,
+        );
+
+        // then
+        expect(acceptCompanionUsecase).toHaveBeenCalledWith({ userId: 123, foundJourneyId: 234 });
+        expect(next).toHaveBeenCalledWith(new Error("Error message"));
+        expect(res.status).not.toHaveBeenCalled();
+        expect(rejectCompanionUsecase).not.toHaveBeenCalled();
+        expect(acceptPassengerUsecase).not.toHaveBeenCalled();
+        expect(rejectPassengerUsecase).not.toHaveBeenCalled();
+        expect(rejectPassengerUsecase).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("invalid user", () => {
+    describe("Success cases", () => {
+      it("should accept journey and call 201 http status code", async () => {
+        // given
+        const req = {
+          auth: {
+            userId: 123,
+          },
+          params: {
+            foundJourneyId: 234,
+          },
+          body: {
+            updatedStatus: true,
+          },
+        };
+        findUser.mockResolvedValue({ id: 123, role: USER_ROLE.INVALID });
+
+        // when
+        await updateFoundJourneyStatusController(
+          req,
+          res,
+          next,
+          acceptCompanionUsecase,
+          rejectCompanionUsecase,
+          acceptPassengerUsecase,
+          rejectPassengerUsecase,
+          findUser,
+        );
+
+        // then
+        expect(res.status).toHaveBeenCalledWith(201);
+        expect(res.send).toHaveBeenCalled();
+        expect(acceptPassengerUsecase).toHaveBeenCalledWith({ userId: 123, foundJourneyId: 234 });
+        expect(rejectPassengerUsecase).not.toHaveBeenCalled();
+        expect(acceptCompanionUsecase).not.toHaveBeenCalled();
+        expect(rejectCompanionUsecase).not.toHaveBeenCalled();
+        expect(rejectPassengerUsecase).not.toHaveBeenCalled();
+      });
+
+      it("should reject journey and call 201 http status code", async () => {
+        // given
+        const req = {
+          auth: {
+            userId: 123,
+          },
+          params: {
+            foundJourneyId: 234,
+          },
+          body: {
+            updatedStatus: false,
+          },
+        };
+        findUser.mockResolvedValue({ id: 123, role: USER_ROLE.INVALID });
+
+        // when
+        await updateFoundJourneyStatusController(
+          req,
+          res,
+          next,
+          acceptCompanionUsecase,
+          rejectCompanionUsecase,
+          acceptPassengerUsecase,
+          rejectPassengerUsecase,
+          findUser,
+        );
+
+        // then
+        expect(res.status).toHaveBeenCalledWith(201);
+        expect(res.send).toHaveBeenCalled();
+        expect(acceptPassengerUsecase).not.toHaveBeenCalled();
+        expect(rejectPassengerUsecase).toHaveBeenCalledWith({ userId: 123, foundJourneyId: 234 });
+        expect(acceptCompanionUsecase).not.toHaveBeenCalled();
+        expect(rejectCompanionUsecase).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("error cases", () => {
+      it("should throw an error and call next middleware", async () => {
+        // given
+        const req = {
+          auth: {
+            userId: 123,
+          },
+          params: {
+            foundJourneyId: 234,
+          },
+          body: {
+            updatedStatus: true,
+          },
+        };
+        findUser.mockResolvedValue({ id: 123, role: USER_ROLE.INVALID });
+        acceptPassengerUsecase.mockRejectedValue(new Error("Error message"));
+
+        // when
+        await updateFoundJourneyStatusController(
+          req,
+          res,
+          next,
+          acceptCompanionUsecase,
+          rejectCompanionUsecase,
+          acceptPassengerUsecase,
+          rejectPassengerUsecase,
+          findUser,
+        );
+
+        // then
+        expect(next).toHaveBeenCalledWith(new Error("Error message"));
+        expect(acceptPassengerUsecase).toHaveBeenCalledWith({ userId: 123, foundJourneyId: 234 });
+        expect(res.status).not.toHaveBeenCalled();
+        expect(acceptCompanionUsecase).not.toHaveBeenCalled();
+        expect(rejectCompanionUsecase).not.toHaveBeenCalled();
+        expect(rejectPassengerUsecase).not.toHaveBeenCalled();
+        expect(rejectPassengerUsecase).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("user without role", () => {
+    it("should throw an error and call next middleware if user has no role", async () => {
+      // given
+      const req = {
+        auth: {
+          userId: 123,
+        },
+        params: {
+          foundJourneyId: 234,
+        },
+        body: {
+          updatedStatus: true,
+        },
+      };
+      findUser.mockResolvedValue({ id: 123 });
+
+      // when
+      await updateFoundJourneyStatusController(
+        req,
+        res,
+        next,
+        acceptCompanionUsecase,
+        rejectCompanionUsecase,
+        acceptPassengerUsecase,
+        rejectPassengerUsecase,
+        findUser,
+      );
+
+      // then
+      expect(findUser).toHaveBeenCalledWith(123);
+      expect(next).toHaveBeenCalledWith(new UserHasNoRole);
+      expect(acceptPassengerUsecase).not.toHaveBeenCalled();
+      expect(res.status).not.toHaveBeenCalled();
+      expect(acceptCompanionUsecase).not.toHaveBeenCalled();
+      expect(rejectCompanionUsecase).not.toHaveBeenCalled();
+      expect(rejectPassengerUsecase).not.toHaveBeenCalled();
+      expect(rejectPassengerUsecase).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/api/tests/journeys/unit/utils/check-found-journey-status.test.js
+++ b/api/tests/journeys/unit/utils/check-found-journey-status.test.js
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  AlreadyAccepted,
+  AlreadyCancelled,
+  AlreadyRejected,
+} from "../../../../src/journeys/errors.js";
+import { checkFoundJourneyStatus } from "../../../../src/journeys/utils/check-found-journey-status.js";
+import { JOURNEY_STATUS } from "../../../../src/shared/constants.js";
+
+describe("Unit | Journeys | Utils | Check found journey status", () => {
+  it("should throw AlreadyAccepted when status is already accepted and updated to accepted", () => {
+    // given
+    const params = {
+      oupdatedStatus: JOURNEY_STATUS.ACCEPTED,
+      updatedStatus: JOURNEY_STATUS.ACCEPTED,
+    };
+
+    // when
+    function action() {
+      return checkFoundJourneyStatus(params);
+    }
+
+    // then
+    expect(action).toThrow(AlreadyAccepted);
+  });
+
+  it("should throw AlreadyCancelled when status is already cancelled and updated to cancelled", () => {
+    // given
+    const params = {
+      oupdatedStatus: JOURNEY_STATUS.CANCELLED,
+      updatedStatus: JOURNEY_STATUS.CANCELLED,
+    };
+
+
+    // when
+    function action() {
+      return checkFoundJourneyStatus(params);
+    }
+
+    // then
+    expect(action).toThrow(AlreadyCancelled);
+  });
+
+  it("should throw AlreadyRejected when status is already rejected and updated to rejected", () => {
+    // given
+    const params = {
+      oupdatedStatus: JOURNEY_STATUS.REJECTED,
+      updatedStatus: JOURNEY_STATUS.REJECTED,
+    };
+
+
+    // when
+    function action() {
+      return checkFoundJourneyStatus(params);
+    }
+
+    // then
+    expect(action).toThrow(AlreadyRejected);
+  });
+
+  it("should throw AlreadyAccepted when current status is accepted and updated to another status", () => {
+    // given
+    const params = {
+      oupdatedStatus: JOURNEY_STATUS.ACCEPTED,
+      updatedStatus: JOURNEY_STATUS.REJECTED,
+    };
+
+
+    // when
+    function action() {
+      return checkFoundJourneyStatus(params);
+    }
+
+    // then
+    expect(action).toThrow(AlreadyAccepted);
+  });
+
+  it("should throw AlreadyCancelled when current status is cancelled and updated to another status", () => {
+    // given
+    const params = {
+      oupdatedStatus: JOURNEY_STATUS.CANCELLED,
+      updatedStatus: JOURNEY_STATUS.ACCEPTED,
+    };
+
+
+    // when
+    function action() {
+      return checkFoundJourneyStatus(params);
+    }
+
+    // then
+    expect(action).toThrow(AlreadyCancelled);
+  });
+
+  it("should throw AlreadyRejected when current status is rejected and updated to another status", () => {
+    // given
+    const params = {
+      oupdatedStatus: JOURNEY_STATUS.REJECTED,
+      updatedStatus: JOURNEY_STATUS.ACCEPTED,
+    };
+
+
+    // when
+    function action() {
+      return checkFoundJourneyStatus(params);
+    }
+
+    // then
+    expect(action).toThrow(AlreadyRejected);
+  });
+
+  it("should not throw when current status is waiting and updated to accepted", () => {
+    // given
+    const params = {
+      oupdatedStatus: JOURNEY_STATUS.WAITING,
+      updatedStatus: JOURNEY_STATUS.ACCEPTED,
+    };
+
+
+    // when
+    function action() {
+      return checkFoundJourneyStatus(params);
+    }
+
+    // then
+    expect(action).not.toThrow();
+  });
+
+  it("should not throw when current status is waiting and updated to rejected", () => {
+    // given
+    const params = {
+      oupdatedStatus: JOURNEY_STATUS.WAITING,
+      updatedStatus: JOURNEY_STATUS.REJECTED,
+    };
+
+
+    // when
+    function action() {
+      return checkFoundJourneyStatus(params);
+    }
+
+    // then
+    expect(action).not.toThrow();
+  });
+
+  it("should not throw when current status is waiting and updated to cancelled", () => {
+    // given
+    const params = {
+      oupdatedStatus: JOURNEY_STATUS.WAITING,
+      updatedStatus: JOURNEY_STATUS.CANCELLED,
+    };
+
+
+    // when
+    function action() {
+      return checkFoundJourneyStatus(params);
+    }
+
+    // then
+    expect(action).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Problem
We need to have a route to accept or decline a found journey. With different usecases, valid or invalid users. The route must be secure and a simple PUT.

## Solution
- Switch table found_journeys on a new status type with one status column for one user role,
- Create repositories to interact with database,
- Create some usecases for different possibilities,
- Create a controller to manage route,
- Create the endpoint protected by the authMiddleware checking and schema verification.

### Also fix in
- Fix the swagger script,
- Remove some constants because there was not used with new system.