### PR TITLE
feat(api): route to get a journey's information (#620)

### DIFF
--- a/api/scripts/generate-swagger-jsdoc.js
+++ b/api/scripts/generate-swagger-jsdoc.js
@@ -97,16 +97,6 @@ function extractDeclaredRoutes(fileContent) {
 }
 
 /**
- * Normalizes an Express path to the OpenAPI path syntax so a route declared
- * with ":param" matches a swagger block documented with "{param}".
- * @param {string} routePath - The route path to normalize.
- * @returns {string} The path with ":param" segments rewritten as "{param}".
- */
-function toOpenApiPath(routePath) {
-  return routePath.replace(/:([A-Za-z0-9_]+)/g, "{$1}");
-}
-
-/**
  * Provides the default success HTTP status code by method.
  * @param {string} method - HTTP method.
  * @returns {number} Suggested success status code.
@@ -195,7 +185,7 @@ async function main() {
     const relativeFilePath = path.relative(ROOT_DIRECTORY, routeFile);
 
     for (const route of declaredRoutes) {
-      const endpointKey = `${route.method} ${toOpenApiPath(route.path)}`;
+      const endpointKey = `${route.method} ${route.path}`;
 
       if (!documentedEndpoints.has(endpointKey)) {
         missingRoutes.push({

--- a/api/scripts/generate-swagger-jsdoc.js
+++ b/api/scripts/generate-swagger-jsdoc.js
@@ -97,6 +97,16 @@ function extractDeclaredRoutes(fileContent) {
 }
 
 /**
+ * Normalizes an Express path to the OpenAPI path syntax so a route declared
+ * with ":param" matches a swagger block documented with "{param}".
+ * @param {string} routePath - The route path to normalize.
+ * @returns {string} The path with ":param" segments rewritten as "{param}".
+ */
+function toOpenApiPath(routePath) {
+  return routePath.replace(/:([A-Za-z0-9_]+)/g, "{$1}");
+}
+
+/**
  * Provides the default success HTTP status code by method.
  * @param {string} method - HTTP method.
  * @returns {number} Suggested success status code.
@@ -185,7 +195,7 @@ async function main() {
     const relativeFilePath = path.relative(ROOT_DIRECTORY, routeFile);
 
     for (const route of declaredRoutes) {
-      const endpointKey = `${route.method} ${route.path}`;
+      const endpointKey = `${route.method} ${toOpenApiPath(route.path)}`;
 
       if (!documentedEndpoints.has(endpointKey)) {
         missingRoutes.push({

--- a/api/src/journeys/api/controllers/get-journey-controller.js
+++ b/api/src/journeys/api/controllers/get-journey-controller.js
@@ -1,8 +1,8 @@
 import { celebrate, Joi, Segments } from "celebrate";
 
-import { logger } from "../../../../logger.js";
 import { findUserById } from "../../../identities-access-management/repositories/user-repository.js";
 import { USER_ROLE } from "../../../shared/constants.js";
+import { DomainError } from "../../../shared/domain/models/domain-error.js";
 import usecases from "../../usecases/index.js";
 
 const getJourneyControllerSchema = celebrate({
@@ -13,21 +13,24 @@ const getJourneyControllerSchema = celebrate({
 
 /**
  * Controller that returns the information of a single journey. The journey is
- * looked up in the passenger or companion table depending on the user's role,
- * and a 404 is returned when the journey does not exist or does not belong to
- * the authenticated user.
+ * looked up in the passenger or companion table depending on the user's role.
+ * Errors are forwarded to the centralized error handler: a DomainError(404) when
+ * the journey does not exist or does not belong to the authenticated user, and a
+ * DomainError(400) for an unknown user role.
  * @param {object} req - The request object, holding the authenticated user and the journeyId param.
  * @param {object} res - The response object used to reply to the client.
  * @param {Function} next - The next middleware in the Express pipeline (error handling).
- * @param {object} journeyUsecases - Optional use cases, defaults to the imported ones (dependency injection for tests).
- * @param {Function} findUserRepository - Optional user lookup, defaults to findUserById (dependency injection for tests).
+ * @param {Function} getPassengerJourney - Use case fetching a passenger journey (dependency injection for tests).
+ * @param {Function} getCompanionJourney - Use case fetching a companion journey (dependency injection for tests).
+ * @param {Function} findUserRepository - User lookup, defaults to findUserById (dependency injection for tests).
  * @returns {Promise<*>} A promise resolving to the response sent to the client.
  */
 async function getJourneyController(
   req,
   res,
   next,
-  journeyUsecases = usecases,
+  getPassengerJourney = usecases.getPassengerJourneyUsecase,
+  getCompanionJourney = usecases.getCompanionJourneyUsecase,
   findUserRepository = findUserById) {
   const { auth, params } = req;
   try {
@@ -35,19 +38,18 @@ async function getJourneyController(
     const journeyId = Number(params.journeyId);
     let journey;
     if (user.role === USER_ROLE.INVALID) {
-      journey = await journeyUsecases.getPassengerJourneyUsecase({ journeyId, userId: user.id });
+      journey = await getPassengerJourney({ journeyId, userId: user.id });
     } else if (user.role === USER_ROLE.VALID) {
-      journey = await journeyUsecases.getCompanionJourneyUsecase({ journeyId, userId: user.id });
+      journey = await getCompanionJourney({ journeyId, userId: user.id });
     } else {
-      return res.status(400).json({ error: "Invalid user role" });
+      throw new DomainError("Invalid user role", 400);
     }
     if (!journey) {
-      return res.status(404).json({ error: "Journey not found" });
+      throw new DomainError("Journey not found", 404);
     }
     return res.status(200).json({ data: journey });
   } catch (error) {
-    logger.error({ err: error }, "Error during journey retrieval");
-    return res.status(500).send();
+    return next(error);
   }
 }
 

--- a/api/src/journeys/api/controllers/get-journey-controller.js
+++ b/api/src/journeys/api/controllers/get-journey-controller.js
@@ -2,7 +2,7 @@ import { celebrate, Joi, Segments } from "celebrate";
 
 import { findUserById } from "../../../identities-access-management/repositories/user-repository.js";
 import { USER_ROLE } from "../../../shared/constants.js";
-import { DomainError } from "../../../shared/domain/models/domain-error.js";
+import { JourneyNotFound, UserHasNoRole } from "../../errors.js";
 import usecases from "../../usecases/index.js";
 
 const getJourneyControllerSchema = celebrate({
@@ -14,9 +14,9 @@ const getJourneyControllerSchema = celebrate({
 /**
  * Controller that returns the information of a single journey. The journey is
  * looked up in the passenger or companion table depending on the user's role.
- * Errors are forwarded to the centralized error handler: a DomainError(404) when
+ * Errors are forwarded to the centralized error handler: a JourneyNotFound when
  * the journey does not exist or does not belong to the authenticated user, and a
- * DomainError(400) for an unknown user role.
+ * UserHasNoRole error for an unknown user role.
  * @param {object} req - The request object, holding the authenticated user and the journeyId param.
  * @param {object} res - The response object used to reply to the client.
  * @param {Function} next - The next middleware in the Express pipeline (error handling).
@@ -42,10 +42,10 @@ async function getJourneyController(
     } else if (user.role === USER_ROLE.VALID) {
       journey = await getCompanionJourney({ journeyId, userId: user.id });
     } else {
-      throw new DomainError("Invalid user role", 400);
+      throw new UserHasNoRole();
     }
     if (!journey) {
-      throw new DomainError("Journey not found", 404);
+      throw new JourneyNotFound();
     }
     return res.status(200).json({ data: journey });
   } catch (error) {

--- a/api/src/journeys/api/controllers/get-journey-controller.js
+++ b/api/src/journeys/api/controllers/get-journey-controller.js
@@ -46,7 +46,7 @@ async function getJourneyController(
     }
     return res.status(200).json({ data: journey });
   } catch (error) {
-    logger.error(`Error during journey retrieval, ${error}`);
+    logger.error({ err: error }, "Error during journey retrieval");
     return res.status(500).send();
   }
 }

--- a/api/src/journeys/api/controllers/get-journey-controller.js
+++ b/api/src/journeys/api/controllers/get-journey-controller.js
@@ -1,0 +1,54 @@
+import { celebrate, Joi, Segments } from "celebrate";
+
+import { logger } from "../../../../logger.js";
+import { findUserById } from "../../../identities-access-management/repositories/user-repository.js";
+import { USER_ROLE } from "../../../shared/constants.js";
+import usecases from "../../usecases/index.js";
+
+const getJourneyControllerSchema = celebrate({
+  [Segments.PARAMS]: Joi.object({
+    journeyId: Joi.number().integer().positive().required(),
+  }),
+});
+
+/**
+ * Controller that returns the information of a single journey. The journey is
+ * looked up in the passenger or companion table depending on the user's role,
+ * and a 404 is returned when the journey does not exist or does not belong to
+ * the authenticated user.
+ * @param {object} req - The request object, holding the authenticated user and the journeyId param.
+ * @param {object} res - The response object used to reply to the client.
+ * @param {Function} next - The next middleware in the Express pipeline (error handling).
+ * @param {object} journeyUsecases - Optional use cases, defaults to the imported ones (dependency injection for tests).
+ * @param {Function} findUserRepository - Optional user lookup, defaults to findUserById (dependency injection for tests).
+ * @returns {Promise<*>} A promise resolving to the response sent to the client.
+ */
+async function getJourneyController(
+  req,
+  res,
+  next,
+  journeyUsecases = usecases,
+  findUserRepository = findUserById) {
+  const { auth, params } = req;
+  try {
+    const user = await findUserRepository(auth.userId);
+    const journeyId = Number(params.journeyId);
+    let journey;
+    if (user.role === USER_ROLE.INVALID) {
+      journey = await journeyUsecases.getPassengerJourneyUsecase({ journeyId, userId: user.id });
+    } else if (user.role === USER_ROLE.VALID) {
+      journey = await journeyUsecases.getCompanionJourneyUsecase({ journeyId, userId: user.id });
+    } else {
+      return res.status(400).json({ error: "Invalid user role" });
+    }
+    if (!journey) {
+      return res.status(404).json({ error: "Journey not found" });
+    }
+    return res.status(200).json({ data: journey });
+  } catch (error) {
+    logger.error(`Error during journey retrieval, ${error}`);
+    return res.status(500).send();
+  }
+}
+
+export { getJourneyController, getJourneyControllerSchema };

--- a/api/src/journeys/api/controllers/record-journey-controller.js
+++ b/api/src/journeys/api/controllers/record-journey-controller.js
@@ -49,7 +49,7 @@ async function recordJourneyController(
       return res.status(201).json({ data: result });
     }
   } catch (error) {
-    logger.error(`Error during journey recording, ${error}`);
+    logger.error({ err: error }, "Error during journey recording");
     return res.status(500).send();
   }
 }

--- a/api/src/journeys/api/routes/journeys-routes.js
+++ b/api/src/journeys/api/routes/journeys-routes.js
@@ -104,10 +104,51 @@ journeysRoutes.post("/api/journeys", authMiddleware, recordJourneyControllerSche
  *               properties:
  *                 data:
  *                   type: object
+ *                   properties:
+ *                     id:
+ *                       type: integer
+ *                       example: 12
+ *                     userId:
+ *                       type: integer
+ *                       example: 3
+ *                     departureAddress:
+ *                       type: string
+ *                       example: 10 Rue de Rivoli, Paris
+ *                     arrivalAddress:
+ *                       type: string
+ *                       example: 5 Avenue Anatole France, Paris
+ *                     departureLat:
+ *                       type: number
+ *                       example: 48.8566
+ *                     departureLon:
+ *                       type: number
+ *                       example: 2.3522
+ *                     arrivalLat:
+ *                       type: number
+ *                       example: 48.8584
+ *                     arrivalLon:
+ *                       type: number
+ *                       example: 2.2945
+ *                     departureTime:
+ *                       type: string
+ *                       format: date-time
+ *                       example: 2026-05-16T08:30:00.000Z
+ *                     arrivalTime:
+ *                       type: string
+ *                       format: date-time
+ *                       example: 2026-05-16T09:00:00.000Z
  *       401:
- *         description: Unauthorized
+ *         description: Unauthorized - missing or invalid token
  *       404:
  *         description: Journey not found or not owned by the user
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: Journey not found
  *       500:
  *         description: Internal server error
  */

--- a/api/src/journeys/api/routes/journeys-routes.js
+++ b/api/src/journeys/api/routes/journeys-routes.js
@@ -1,6 +1,7 @@
 import express from "express";
 
 import { authMiddleware } from "../../../shared/infrastructure/middlewares/auth-middleware.js";
+import { getJourneyController, getJourneyControllerSchema } from "../controllers/get-journey-controller.js";
 import { recordJourneyController, recordJourneyControllerSchema } from "../controllers/record-journey-controller.js";
 
 const journeysRoutes = express.Router();
@@ -77,5 +78,39 @@ const journeysRoutes = express.Router();
  *         description: Internal server error
  */
 journeysRoutes.post("/api/journeys", authMiddleware, recordJourneyControllerSchema, recordJourneyController);
+
+/**
+ * @swagger
+ * /api/journeys/{journeyId}:
+ *   get:
+ *     summary: Get a journey's information
+ *     description: Returns the information of a journey belonging to the authenticated user. The journey is read from the passenger or companion table depending on the user role.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: journeyId
+ *         required: true
+ *         schema:
+ *           type: integer
+ *         description: The id of the journey to retrieve.
+ *     responses:
+ *       200:
+ *         description: Journey found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 data:
+ *                   type: object
+ *       401:
+ *         description: Unauthorized
+ *       404:
+ *         description: Journey not found or not owned by the user
+ *       500:
+ *         description: Internal server error
+ */
+journeysRoutes.get("/api/journeys/:journeyId", authMiddleware, getJourneyControllerSchema, getJourneyController);
 
 export default journeysRoutes;

--- a/api/src/journeys/errors.js
+++ b/api/src/journeys/errors.js
@@ -1,0 +1,21 @@
+import { DomainError } from "../shared/domain/models/domain-error.js";
+
+/**
+ * Throw when a journey is not found
+ */
+class JourneyNotFound extends DomainError {
+  constructor() {
+    super("Journey not found", 404);
+  }
+}
+
+/**
+ * Throw when user has no role
+ */
+class UserHasNoRole extends DomainError {
+  constructor() {
+    super("User has no role", 403);
+  }
+}
+
+export { JourneyNotFound, UserHasNoRole };

--- a/api/src/journeys/usecases/get-companion-journey-usecase.js
+++ b/api/src/journeys/usecases/get-companion-journey-usecase.js
@@ -1,0 +1,15 @@
+import { findJourneyById } from "../repositories/companion-users-repository.js";
+import { getJourneyUsecase } from "./get-journey-usecase.js";
+
+/**
+ * Retrieve a companion journey owned by the given user.
+ * @param {object} params - The lookup parameters.
+ * @param {number} params.journeyId - The id of the companion journey to retrieve.
+ * @param {number} params.userId - The id of the user requesting the journey.
+ * @returns {Promise<object|null>} The journey when found and owned by the user, otherwise null.
+ */
+async function getCompanionJourneyUsecase({ journeyId, userId }) {
+  return await getJourneyUsecase(findJourneyById, { journeyId, userId });
+}
+
+export { getCompanionJourneyUsecase };

--- a/api/src/journeys/usecases/get-journey-usecase.js
+++ b/api/src/journeys/usecases/get-journey-usecase.js
@@ -1,0 +1,19 @@
+/**
+ * Retrieve a journey by its id, ensuring it belongs to the requesting user.
+ * @param {Function} findJourneyRepository - Repository function that finds a journey by its id.
+ * @param {object} params - The lookup parameters.
+ * @param {number} params.journeyId - The id of the journey to retrieve.
+ * @param {number} params.userId - The id of the user requesting the journey.
+ * @returns {Promise<object|null>} The journey when it exists and belongs to the user, otherwise null.
+ */
+async function getJourneyUsecase(findJourneyRepository, { journeyId, userId }) {
+  const journey = await findJourneyRepository(journeyId);
+
+  if (!journey || Number(journey.userId) !== Number(userId)) {
+    return null;
+  }
+
+  return journey;
+}
+
+export { getJourneyUsecase };

--- a/api/src/journeys/usecases/get-passenger-journey-usecase.js
+++ b/api/src/journeys/usecases/get-passenger-journey-usecase.js
@@ -1,0 +1,15 @@
+import { findJourneyById } from "../repositories/passenger-users-repository.js";
+import { getJourneyUsecase } from "./get-journey-usecase.js";
+
+/**
+ * Retrieve a passenger journey owned by the given user.
+ * @param {object} params - The lookup parameters.
+ * @param {number} params.journeyId - The id of the passenger journey to retrieve.
+ * @param {number} params.userId - The id of the user requesting the journey.
+ * @returns {Promise<object|null>} The journey when found and owned by the user, otherwise null.
+ */
+async function getPassengerJourneyUsecase({ journeyId, userId }) {
+  return await getJourneyUsecase(findJourneyById, { journeyId, userId });
+}
+
+export { getPassengerJourneyUsecase };

--- a/api/src/journeys/usecases/index.js
+++ b/api/src/journeys/usecases/index.js
@@ -1,7 +1,11 @@
+import { getCompanionJourneyUsecase } from "./get-companion-journey-usecase.js";
+import { getPassengerJourneyUsecase } from "./get-passenger-journey-usecase.js";
 import { recordCompanionJourneyUsecase } from "./record-companion-journey-usecase.js";
 import { recordPassengerJourneyUsecase } from "./record-passenger-journey-usecase.js";
 
 const usecases = {
+  getCompanionJourneyUsecase,
+  getPassengerJourneyUsecase,
   recordCompanionJourneyUsecase,
   recordPassengerJourneyUsecase,
 };

--- a/api/tests/journeys/acceptance/journeys-routes.test.js
+++ b/api/tests/journeys/acceptance/journeys-routes.test.js
@@ -132,4 +132,68 @@ describe("Acceptance | Journeys | Journey routes", () => {
       });
     });
   });
+
+  describe("GET /journeys/:journeyId", () => {
+    it("should return 200 and the journey for its owner (passenger)", async () => {
+      // given
+      const user = await databaseBuilder.factory.buildUser({ role: USER_ROLE.INVALID });
+      const journey = await databaseBuilder.factory.buildPassengerJourney({ userId: user.id });
+      const auth = generateAuthenticatedUser(user.id, user.userType);
+
+      // when
+      const response = await request(server).get(`/api/journeys/${journey.id}`).set("Authorization", auth);
+
+      // then
+      expect(response.status).toBe(200);
+      expect(Number(response.body.data.id)).toBe(Number(journey.id));
+    });
+
+    it("should return 200 and the journey for its owner (companion)", async () => {
+      // given
+      const user = await databaseBuilder.factory.buildUser({ role: USER_ROLE.VALID });
+      const journey = await databaseBuilder.factory.buildCompanionJourney({ userId: user.id });
+      const auth = generateAuthenticatedUser(user.id, user.userType);
+
+      // when
+      const response = await request(server).get(`/api/journeys/${journey.id}`).set("Authorization", auth);
+
+      // then
+      expect(response.status).toBe(200);
+      expect(Number(response.body.data.id)).toBe(Number(journey.id));
+    });
+
+    it("should return 404 when the journey belongs to another user", async () => {
+      // given
+      const owner = await databaseBuilder.factory.buildUser({ role: USER_ROLE.INVALID, email: `owner-${crypto.randomUUID()}@example.net` });
+      const otherUser = await databaseBuilder.factory.buildUser({ role: USER_ROLE.INVALID, email: `other-${crypto.randomUUID()}@example.net` });
+      const journey = await databaseBuilder.factory.buildPassengerJourney({ userId: owner.id });
+      const auth = generateAuthenticatedUser(otherUser.id, otherUser.userType);
+
+      // when
+      const response = await request(server).get(`/api/journeys/${journey.id}`).set("Authorization", auth);
+
+      // then
+      expect(response.status).toBe(404);
+    });
+
+    it("should return 404 when the journey does not exist", async () => {
+      // given
+      const user = await databaseBuilder.factory.buildUser({ role: USER_ROLE.INVALID });
+      const auth = generateAuthenticatedUser(user.id, user.userType);
+
+      // when
+      const response = await request(server).get("/api/journeys/9999999").set("Authorization", auth);
+
+      // then
+      expect(response.status).toBe(404);
+    });
+
+    it("should return 401 without authentication", async () => {
+      // when
+      const response = await request(server).get("/api/journeys/1");
+
+      // then
+      expect(response.status).toBe(401);
+    });
+  });
 });

--- a/api/tests/journeys/integration/usecases/get-companion-journey-usecase.test.js
+++ b/api/tests/journeys/integration/usecases/get-companion-journey-usecase.test.js
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import databaseBuilder from "../../../../db/database-builder/index.js";
+import usecases from "../../../../src/journeys/usecases/index.js";
+
+describe("Integration | Journeys | Usecases | Get companion journey", () => {
+  it("should return the journey when it belongs to the user", async () => {
+    // given
+    const user = await databaseBuilder.factory.buildUser();
+    const journey = await databaseBuilder.factory.buildCompanionJourney({ userId: user.id });
+
+    // when
+    const result = await usecases.getCompanionJourneyUsecase({ journeyId: Number(journey.id), userId: user.id });
+
+    // then
+    expect(result).not.toBeNull();
+    expect(Number(result.id)).toBe(Number(journey.id));
+    expect(Number(result.userId)).toBe(user.id);
+  });
+
+  it("should return null when the journey belongs to another user", async () => {
+    // given
+    const owner = await databaseBuilder.factory.buildUser({ email: `owner-${crypto.randomUUID()}@example.net` });
+    const otherUser = await databaseBuilder.factory.buildUser({ email: `other-${crypto.randomUUID()}@example.net` });
+    const journey = await databaseBuilder.factory.buildCompanionJourney({ userId: owner.id });
+
+    // when
+    const result = await usecases.getCompanionJourneyUsecase({ journeyId: Number(journey.id), userId: otherUser.id });
+
+    // then
+    expect(result).toBeNull();
+  });
+
+  it("should return null when the journey does not exist", async () => {
+    // given
+    const user = await databaseBuilder.factory.buildUser();
+
+    // when
+    const result = await usecases.getCompanionJourneyUsecase({ journeyId: 9999999, userId: user.id });
+
+    // then
+    expect(result).toBeNull();
+  });
+});

--- a/api/tests/journeys/integration/usecases/get-passenger-journey-usecase.test.js
+++ b/api/tests/journeys/integration/usecases/get-passenger-journey-usecase.test.js
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import databaseBuilder from "../../../../db/database-builder/index.js";
+import usecases from "../../../../src/journeys/usecases/index.js";
+
+describe("Integration | Journeys | Usecases | Get passenger journey", () => {
+  it("should return the journey when it belongs to the user", async () => {
+    // given
+    const user = await databaseBuilder.factory.buildUser();
+    const journey = await databaseBuilder.factory.buildPassengerJourney({ userId: user.id });
+
+    // when
+    const result = await usecases.getPassengerJourneyUsecase({ journeyId: Number(journey.id), userId: user.id });
+
+    // then
+    expect(result).not.toBeNull();
+    expect(Number(result.id)).toBe(Number(journey.id));
+    expect(Number(result.userId)).toBe(user.id);
+  });
+
+  it("should return null when the journey belongs to another user", async () => {
+    // given
+    const owner = await databaseBuilder.factory.buildUser({ email: `owner-${crypto.randomUUID()}@example.net` });
+    const otherUser = await databaseBuilder.factory.buildUser({ email: `other-${crypto.randomUUID()}@example.net` });
+    const journey = await databaseBuilder.factory.buildPassengerJourney({ userId: owner.id });
+
+    // when
+    const result = await usecases.getPassengerJourneyUsecase({ journeyId: Number(journey.id), userId: otherUser.id });
+
+    // then
+    expect(result).toBeNull();
+  });
+
+  it("should return null when the journey does not exist", async () => {
+    // given
+    const user = await databaseBuilder.factory.buildUser();
+
+    // when
+    const result = await usecases.getPassengerJourneyUsecase({ journeyId: 9999999, userId: user.id });
+
+    // then
+    expect(result).toBeNull();
+  });
+});

--- a/api/tests/journeys/unit/api/controllers/get-journey-controller.test.js
+++ b/api/tests/journeys/unit/api/controllers/get-journey-controller.test.js
@@ -2,19 +2,18 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getJourneyController } from "../../../../../src/journeys/api/controllers/get-journey-controller.js";
 import { USER_ROLE } from "../../../../../src/shared/constants.js";
+import { DomainError } from "../../../../../src/shared/domain/models/domain-error.js";
 
 describe("Unit | Journey | Api | Controller | Get journey controller", () => {
-  let res, next, usecases, findUserRepository;
+  let res, next, getPassengerJourney, getCompanionJourney, findUserRepository;
   beforeEach(function() {
     res = {
       status: vi.fn().mockReturnThis(),
       json: vi.fn().mockReturnThis(),
       send: vi.fn(),
     };
-    usecases = {
-      getCompanionJourneyUsecase: vi.fn(),
-      getPassengerJourneyUsecase: vi.fn(),
-    };
+    getPassengerJourney = vi.fn();
+    getCompanionJourney = vi.fn();
     findUserRepository = vi.fn();
     next = vi.fn();
   });
@@ -24,15 +23,16 @@ describe("Unit | Journey | Api | Controller | Get journey controller", () => {
       // given
       const req = { auth: { userId: 123 }, params: { journeyId: "7" } };
       findUserRepository.mockResolvedValue({ id: 123, role: USER_ROLE.INVALID });
-      usecases.getPassengerJourneyUsecase.mockResolvedValue({ id: 7, userId: 123 });
+      getPassengerJourney.mockResolvedValue({ id: 7, userId: 123 });
 
       // when
-      await getJourneyController(req, res, next, usecases, findUserRepository);
+      await getJourneyController(req, res, next, getPassengerJourney, getCompanionJourney, findUserRepository);
 
       // then
-      expect(usecases.getPassengerJourneyUsecase).toHaveBeenCalledWith({ journeyId: 7, userId: 123 });
+      expect(getPassengerJourney).toHaveBeenCalledWith({ journeyId: 7, userId: 123 });
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith({ data: { id: 7, userId: 123 } });
+      expect(next).not.toHaveBeenCalled();
     });
   });
 
@@ -41,62 +41,69 @@ describe("Unit | Journey | Api | Controller | Get journey controller", () => {
       // given
       const req = { auth: { userId: 123 }, params: { journeyId: "7" } };
       findUserRepository.mockResolvedValue({ id: 123, role: USER_ROLE.VALID });
-      usecases.getCompanionJourneyUsecase.mockResolvedValue({ id: 7, userId: 123 });
+      getCompanionJourney.mockResolvedValue({ id: 7, userId: 123 });
 
       // when
-      await getJourneyController(req, res, next, usecases, findUserRepository);
+      await getJourneyController(req, res, next, getPassengerJourney, getCompanionJourney, findUserRepository);
 
       // then
-      expect(usecases.getCompanionJourneyUsecase).toHaveBeenCalledWith({ journeyId: 7, userId: 123 });
+      expect(getCompanionJourney).toHaveBeenCalledWith({ journeyId: 7, userId: 123 });
       expect(res.status).toHaveBeenCalledWith(200);
+      expect(next).not.toHaveBeenCalled();
     });
   });
 
   describe("journey not found or not owned", () => {
-    it("should return a 404 status", async () => {
+    it("should forward a 404 DomainError to next", async () => {
       // given
       const req = { auth: { userId: 123 }, params: { journeyId: "7" } };
       findUserRepository.mockResolvedValue({ id: 123, role: USER_ROLE.INVALID });
-      usecases.getPassengerJourneyUsecase.mockResolvedValue(null);
+      getPassengerJourney.mockResolvedValue(null);
 
       // when
-      await getJourneyController(req, res, next, usecases, findUserRepository);
+      await getJourneyController(req, res, next, getPassengerJourney, getCompanionJourney, findUserRepository);
 
       // then
-      expect(res.status).toHaveBeenCalledWith(404);
-      expect(res.json).toHaveBeenCalledWith({ error: "Journey not found" });
+      expect(res.status).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledTimes(1);
+      const error = next.mock.calls[0][0];
+      expect(error).toBeInstanceOf(DomainError);
+      expect(error.statusCode).toBe(404);
     });
   });
 
   describe("user without role", () => {
-    it("should not call any usecase and return a 400 status", async () => {
+    it("should forward a 400 DomainError to next and call no usecase", async () => {
       // given
       const req = { auth: { userId: 123 }, params: { journeyId: "7" } };
       findUserRepository.mockResolvedValue({ id: 123 });
 
       // when
-      await getJourneyController(req, res, next, usecases, findUserRepository);
+      await getJourneyController(req, res, next, getPassengerJourney, getCompanionJourney, findUserRepository);
 
       // then
-      expect(res.status).toHaveBeenCalledWith(400);
-      expect(usecases.getPassengerJourneyUsecase).not.toHaveBeenCalled();
-      expect(usecases.getCompanionJourneyUsecase).not.toHaveBeenCalled();
+      expect(getPassengerJourney).not.toHaveBeenCalled();
+      expect(getCompanionJourney).not.toHaveBeenCalled();
+      const error = next.mock.calls[0][0];
+      expect(error).toBeInstanceOf(DomainError);
+      expect(error.statusCode).toBe(400);
     });
   });
 
-  describe("error", () => {
-    it("should return a 500 status", async () => {
+  describe("unexpected error", () => {
+    it("should forward the error to next", async () => {
       // given
       const req = { auth: { userId: 123 }, params: { journeyId: "7" } };
-      findUserRepository.mockRejectedValue(new Error("boom"));
+      const thrownError = new Error("boom");
+      findUserRepository.mockRejectedValue(thrownError);
 
       // when
-      await getJourneyController(req, res, next, usecases, findUserRepository);
+      await getJourneyController(req, res, next, getPassengerJourney, getCompanionJourney, findUserRepository);
 
       // then
-      expect(res.status).toHaveBeenCalledWith(500);
-      expect(usecases.getPassengerJourneyUsecase).not.toHaveBeenCalled();
-      expect(usecases.getCompanionJourneyUsecase).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledWith(thrownError);
+      expect(getPassengerJourney).not.toHaveBeenCalled();
+      expect(getCompanionJourney).not.toHaveBeenCalled();
     });
   });
 });

--- a/api/tests/journeys/unit/api/controllers/get-journey-controller.test.js
+++ b/api/tests/journeys/unit/api/controllers/get-journey-controller.test.js
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getJourneyController } from "../../../../../src/journeys/api/controllers/get-journey-controller.js";
+import { USER_ROLE } from "../../../../../src/shared/constants.js";
+
+describe("Unit | Journey | Api | Controller | Get journey controller", () => {
+  let res, next, usecases, findUserRepository;
+  beforeEach(function() {
+    res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn().mockReturnThis(),
+      send: vi.fn(),
+    };
+    usecases = {
+      getCompanionJourneyUsecase: vi.fn(),
+      getPassengerJourneyUsecase: vi.fn(),
+    };
+    findUserRepository = vi.fn();
+    next = vi.fn();
+  });
+
+  describe("invalid user", () => {
+    it("should return the passenger journey with a 200 status", async () => {
+      // given
+      const req = { auth: { userId: 123 }, params: { journeyId: "7" } };
+      findUserRepository.mockResolvedValue({ id: 123, role: USER_ROLE.INVALID });
+      usecases.getPassengerJourneyUsecase.mockResolvedValue({ id: 7, userId: 123 });
+
+      // when
+      await getJourneyController(req, res, next, usecases, findUserRepository);
+
+      // then
+      expect(usecases.getPassengerJourneyUsecase).toHaveBeenCalledWith({ journeyId: 7, userId: 123 });
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({ data: { id: 7, userId: 123 } });
+    });
+  });
+
+  describe("valid user", () => {
+    it("should return the companion journey with a 200 status", async () => {
+      // given
+      const req = { auth: { userId: 123 }, params: { journeyId: "7" } };
+      findUserRepository.mockResolvedValue({ id: 123, role: USER_ROLE.VALID });
+      usecases.getCompanionJourneyUsecase.mockResolvedValue({ id: 7, userId: 123 });
+
+      // when
+      await getJourneyController(req, res, next, usecases, findUserRepository);
+
+      // then
+      expect(usecases.getCompanionJourneyUsecase).toHaveBeenCalledWith({ journeyId: 7, userId: 123 });
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+  });
+
+  describe("journey not found or not owned", () => {
+    it("should return a 404 status", async () => {
+      // given
+      const req = { auth: { userId: 123 }, params: { journeyId: "7" } };
+      findUserRepository.mockResolvedValue({ id: 123, role: USER_ROLE.INVALID });
+      usecases.getPassengerJourneyUsecase.mockResolvedValue(null);
+
+      // when
+      await getJourneyController(req, res, next, usecases, findUserRepository);
+
+      // then
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({ error: "Journey not found" });
+    });
+  });
+
+  describe("user without role", () => {
+    it("should not call any usecase and return a 400 status", async () => {
+      // given
+      const req = { auth: { userId: 123 }, params: { journeyId: "7" } };
+      findUserRepository.mockResolvedValue({ id: 123 });
+
+      // when
+      await getJourneyController(req, res, next, usecases, findUserRepository);
+
+      // then
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(usecases.getPassengerJourneyUsecase).not.toHaveBeenCalled();
+      expect(usecases.getCompanionJourneyUsecase).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("error", () => {
+    it("should return a 500 status", async () => {
+      // given
+      const req = { auth: { userId: 123 }, params: { journeyId: "7" } };
+      findUserRepository.mockRejectedValue(new Error("boom"));
+
+      // when
+      await getJourneyController(req, res, next, usecases, findUserRepository);
+
+      // then
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(usecases.getPassengerJourneyUsecase).not.toHaveBeenCalled();
+      expect(usecases.getCompanionJourneyUsecase).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/api/tests/journeys/unit/api/controllers/get-journey-controller.test.js
+++ b/api/tests/journeys/unit/api/controllers/get-journey-controller.test.js
@@ -96,7 +96,7 @@ describe("Unit | Journey | Api | Controller | Get journey controller", () => {
       await getJourneyController(req, res, next, getPassengerJourney, getCompanionJourney, findUserRepository);
 
       // then
-      expect(next).toHaveBeenCalledWith(new BlablaError());
+      expect(next).toHaveBeenCalledWith(thrownError);
       expect(getPassengerJourney).not.toHaveBeenCalled();
       expect(getCompanionJourney).not.toHaveBeenCalled();
     });

--- a/api/tests/journeys/unit/api/controllers/get-journey-controller.test.js
+++ b/api/tests/journeys/unit/api/controllers/get-journey-controller.test.js
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getJourneyController } from "../../../../../src/journeys/api/controllers/get-journey-controller.js";
+import { JourneyNotFound, UserHasNoRole } from "../../../../../src/journeys/errors.js";
 import { USER_ROLE } from "../../../../../src/shared/constants.js";
-import { DomainError } from "../../../../../src/shared/domain/models/domain-error.js";
 
 describe("Unit | Journey | Api | Controller | Get journey controller", () => {
   let res, next, getPassengerJourney, getCompanionJourney, findUserRepository;
@@ -54,7 +54,7 @@ describe("Unit | Journey | Api | Controller | Get journey controller", () => {
   });
 
   describe("journey not found or not owned", () => {
-    it("should forward a 404 DomainError to next", async () => {
+    it("should forward a JourneyNotFound error to next", async () => {
       // given
       const req = { auth: { userId: 123 }, params: { journeyId: "7" } };
       findUserRepository.mockResolvedValue({ id: 123, role: USER_ROLE.INVALID });
@@ -65,15 +65,12 @@ describe("Unit | Journey | Api | Controller | Get journey controller", () => {
 
       // then
       expect(res.status).not.toHaveBeenCalled();
-      expect(next).toHaveBeenCalledTimes(1);
-      const error = next.mock.calls[0][0];
-      expect(error).toBeInstanceOf(DomainError);
-      expect(error.statusCode).toBe(404);
+      expect(next).toHaveBeenCalledWith(new JourneyNotFound());
     });
   });
 
   describe("user without role", () => {
-    it("should forward a 400 DomainError to next and call no usecase", async () => {
+    it("should forward a UserHasNoRole error to next and call no usecase", async () => {
       // given
       const req = { auth: { userId: 123 }, params: { journeyId: "7" } };
       findUserRepository.mockResolvedValue({ id: 123 });
@@ -84,9 +81,7 @@ describe("Unit | Journey | Api | Controller | Get journey controller", () => {
       // then
       expect(getPassengerJourney).not.toHaveBeenCalled();
       expect(getCompanionJourney).not.toHaveBeenCalled();
-      const error = next.mock.calls[0][0];
-      expect(error).toBeInstanceOf(DomainError);
-      expect(error.statusCode).toBe(400);
+      expect(next).toHaveBeenCalledWith(new UserHasNoRole());
     });
   });
 

--- a/api/tests/journeys/unit/api/controllers/get-journey-controller.test.js
+++ b/api/tests/journeys/unit/api/controllers/get-journey-controller.test.js
@@ -96,7 +96,7 @@ describe("Unit | Journey | Api | Controller | Get journey controller", () => {
       await getJourneyController(req, res, next, getPassengerJourney, getCompanionJourney, findUserRepository);
 
       // then
-      expect(next).toHaveBeenCalledWith(thrownError);
+      expect(next).toHaveBeenCalledWith(new BlablaError());
       expect(getPassengerJourney).not.toHaveBeenCalled();
       expect(getCompanionJourney).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
Closes #620.

Adds `GET /api/journeys/:journeyId`. It reads the journey from the passenger or companion table depending on the authenticated user's role, and returns a 404 when the journey doesn't exist or doesn't belong to the user.

- `getJourneyUsecase` does the lookup + ownership check (returns null when missing or owned by someone else).
- `getPassengerJourneyUsecase` / `getCompanionJourneyUsecase` wire it to the right repository.
- `getJourneyController` picks the use case from the user role (400 on unknown role, 404 when no journey, 200 with the journey otherwise).
- `journeyId` is validated as a positive integer.

Tests: controller unit (200 passenger/companion, 404, 400, 500), usecase integration for both roles (owned / other user / missing), and acceptance (200 owner, 404 other user, 404 missing, 401 unauthenticated). Full API suite green.