### PR TITLE
fix: Use the jwt token in headers to activate an account

### DIFF
--- a/api/src/identities-access-management/controllers/activate-user-controller.js
+++ b/api/src/identities-access-management/controllers/activate-user-controller.js
@@ -1,7 +1,15 @@
+import { celebrate, Joi, Segments } from "celebrate";
+
 import { logger } from "../../../logger.js";
 import ERRORS, { MESSAGE } from "../errors.js";
 import { activateUserById, findUserById } from "../repositories/user-repository.js";
 import { decodedToken } from "../services/token-service.js";
+
+const activateUserSchema = celebrate({
+  [Segments.HEADERS]: Joi.object({
+    authorization: Joi.string().pattern(/^Bearer .+$/).required(),
+  }).unknown(),
+});
 
 /**
  * Activate User Controller
@@ -22,12 +30,7 @@ async function activateUserController(
   decodedTokenService = decodedToken,
 ) {
   try {
-    const { token } = req.query;
-
-    if (!token) {
-      logger.warn("Activation attempt without token");
-      return res.status(400).json({ error: ERRORS.TOKEN.REQUIRED });
-    }
+    const token = req.headers.authorization.split(" ")[1];
 
     const decodedData = decodedTokenService(token);
     const userId = decodedData.userId;
@@ -53,5 +56,5 @@ async function activateUserController(
   }
 }
 
-export { activateUserController };
+export { activateUserController, activateUserSchema };
 

--- a/api/src/identities-access-management/controllers/activate-user-controller.js
+++ b/api/src/identities-access-management/controllers/activate-user-controller.js
@@ -51,7 +51,7 @@ async function activateUserController(
 
     return res.status(201).json({ message: MESSAGE.USER_ACTIVATED_SUCCESSFULLY });
   } catch (error) {
-    logger.error(`Error during user activation ${error}`);
+    logger.error({ err: error }, "Error during user activation");
     return res.status(500).json({ error: ERRORS.INTERNAL_SERVER_ERROR });
   }
 }

--- a/api/src/identities-access-management/errors.js
+++ b/api/src/identities-access-management/errors.js
@@ -1,6 +1,5 @@
 const ERRORS = {
   TOKEN: {
-    REQUIRED: "Token is required",
     EXPIRED_TOKEN: "Token has expired",
     INVALID_TOKEN: "Invalid or expired token",
     VERIFICATION_FAILED: "Token verification failed",

--- a/api/src/identities-access-management/routes/authentication-routes.js
+++ b/api/src/identities-access-management/routes/authentication-routes.js
@@ -1,6 +1,6 @@
 import express from "express";
 
-import { activateUserController } from "../controllers/activate-user-controller.js";
+import { activateUserController, activateUserSchema } from "../controllers/activate-user-controller.js";
 import { authenticateUserController, authenticateUserSchema } from "../controllers/authenticate-user-controller.js";
 import { registerUserController, registerUserSchema } from "../controllers/register-user-controller.js";
 
@@ -100,13 +100,8 @@ authenticationRoutes.post("/api/authentication/authenticate", authenticateUserSc
  *   get:
  *     summary: Activate a user account
  *     description: Activates a user account using the token sent by email
- *     parameters:
- *       - in: query
- *         name: token
- *         required: true
- *         schema:
- *           type: string
- *         description: Activation token sent by email
+ *     security:
+ *       - bearerAuth: []
  *     responses:
  *       201:
  *         description: User activated successfully
@@ -149,6 +144,6 @@ authenticationRoutes.post("/api/authentication/authenticate", authenticateUserSc
  *                   type: string
  *                   example: Internal server error
  */
-authenticationRoutes.get("/api/authentication/activate", activateUserController);
+authenticationRoutes.get("/api/authentication/activate", activateUserSchema, activateUserController);
 
 export default authenticationRoutes;

--- a/api/tests/identities-access-management/acceptance/authentication-routes.test.js
+++ b/api/tests/identities-access-management/acceptance/authentication-routes.test.js
@@ -76,7 +76,7 @@ describe("Acceptance | Identities Access Management | Routes | Authentication ro
       const token = encodedToken({ userId: user.id });
 
       // when
-      const response = await request(server).get(`/api/authentication/activate?token=${token}`);
+      const response = await request(server).get("/api/authentication/activate").set("authorization", `Bearer ${token}`);
 
       // then
       expect(response.status).toBe(201);
@@ -89,7 +89,7 @@ describe("Acceptance | Identities Access Management | Routes | Authentication ro
 
       // then
       expect(response.status).toBe(400);
-      expect(response.body).toEqual({ error: "Token is required" });
+      expect(response.body.message).toEqual("Validation failed");
     });
 
     it("should return 401 when user does not exist", async () => {
@@ -97,7 +97,7 @@ describe("Acceptance | Identities Access Management | Routes | Authentication ro
       const token = encodedToken({ userId: 999999 });
 
       // when
-      const response = await request(server).get(`/api/authentication/activate?token=${token}`);
+      const response = await request(server).get("/api/authentication/activate").set("authorization", `Bearer ${token}`);
 
       // then
       expect(response.status).toBe(401);
@@ -113,7 +113,7 @@ describe("Acceptance | Identities Access Management | Routes | Authentication ro
       const token = encodedToken({ userId: user.id });
 
       // when
-      const response = await request(server).get(`/api/authentication/activate?token=${token}`);
+      const response = await request(server).get("/api/authentication/activate").set("authorization", `Bearer ${token}`);
 
       // then
       expect(response.status).toBe(401);

--- a/api/tests/identities-access-management/unit/controllers/activate-user-controller.test.js
+++ b/api/tests/identities-access-management/unit/controllers/activate-user-controller.test.js
@@ -10,7 +10,7 @@ describe("Unit | Identities Access Management | Controller | Activate User", () 
     activateUserByIdRepository = vi.fn();
     decodedTokenService = vi.fn();
     req = {
-      query: {},
+      headers: {},
     };
     res = {
       status: vi.fn().mockReturnThis(),
@@ -22,7 +22,7 @@ describe("Unit | Identities Access Management | Controller | Activate User", () 
   describe("success cases", () => {
     it("should activate user and return 201 when token is valid and user is inactive", async () => {
       // given
-      req.query.token = "valid-token";
+      req.headers.authorization = "Bearer valid-token";
       const decodedData = { userId: 123 };
       const user = { id: 123, isActive: false };
 
@@ -43,24 +43,9 @@ describe("Unit | Identities Access Management | Controller | Activate User", () 
   });
 
   describe("error cases", () => {
-    it("should return 400 when token is missing", async () => {
-      // given
-      req.query.token = undefined;
-
-      // when
-      await activateUserController(req, res, next, findUserByIdRepository, activateUserByIdRepository, decodedTokenService);
-
-      // then
-      expect(decodedTokenService).not.toHaveBeenCalled();
-      expect(findUserByIdRepository).not.toHaveBeenCalled();
-      expect(activateUserByIdRepository).not.toHaveBeenCalled();
-      expect(res.status).toHaveBeenCalledWith(400);
-      expect(res.json).toHaveBeenCalledWith({ error: "Token is required" });
-    });
-
     it("should return 401 when user does not exist", async () => {
       // given
-      req.query.token = "valid-token";
+      req.headers.authorization = "Bearer valid-token";
       const decodedData = { userId: 999 };
 
       decodedTokenService.mockReturnValue(decodedData);
@@ -79,7 +64,7 @@ describe("Unit | Identities Access Management | Controller | Activate User", () 
 
     it("should return 401 when user is already active", async () => {
       // given
-      req.query.token = "valid-token";
+      req.headers.authorization = "Bearer valid-token";
       const decodedData = { userId: 123 };
       const user = { id: 123, isActive: true };
 
@@ -99,7 +84,7 @@ describe("Unit | Identities Access Management | Controller | Activate User", () 
 
     it("should return 500 when an unexpected error occurs", async () => {
       // given
-      req.query.token = "valid-token";
+      req.headers.authorization = "Bearer valid-token";
       const decodedData = { userId: 123 };
 
       decodedTokenService.mockReturnValue(decodedData);

--- a/web/src/adapters/authentication.js
+++ b/web/src/adapters/authentication.js
@@ -70,8 +70,11 @@ async function loginUser({ email, password }) {
 
 async function activateAccount({ token }) {
   try {
-    const response = await fetch(`${AUTHENTICATION_URL}activate?token=${encodeURIComponent(token)}`, {
+    const response = await fetch(`${AUTHENTICATION_URL}activate`, {
       method: "GET",
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
     });
 
     switch (response.status) {

--- a/web/tests/unit/adapters/authentication.spec.js
+++ b/web/tests/unit/adapters/authentication.spec.js
@@ -144,24 +144,12 @@ describe("Unit | Adapters | Authentication", () => {
 
       // then
       expect(result).toEqual({ success: true, message: "Compte activé avec succès !" });
-      expect(fetchSpy).toHaveBeenCalledWith("/api/authentication/activate?token=test-activation-token", {
+      expect(fetchSpy).toHaveBeenCalledWith("/api/authentication/activate", {
         method: "GET",
+        headers: {
+          authorization: "Bearer test-activation-token",
+        },
       });
-    });
-
-    it("should encode the token in the URL", async () => {
-      // given
-      const token = "token with spaces & special=chars";
-      const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue({ status: 201 });
-
-      // when
-      await activateAccount({ token });
-
-      // then
-      expect(fetchSpy).toHaveBeenCalledWith(
-        `/api/authentication/activate?token=${encodeURIComponent(token)}`,
-        expect.any(Object),
-      );
     });
 
     it("should return a specific failure message if response status is 400 (invalid token)", async () => {


### PR DESCRIPTION
- **fix(api): use jwt in headers to activate an account**
- **fix(web): past the token in headers for account activation**

## Problem
Actually we past the token in query param for the account activation. In the front, it's possible but for the backend, it's not a security pratic.

## Solution
Past the token in bearer authorization into the backend.

### Note
In the future, it will be interesting to use a specific middleware to check token presence, before schema validation or user checking.

## Test
Create an account on kompagnon and click on the link recived by email or in the console. Check on the network console of your browser that the request contains the headers section with authorization and token.