### PR TITLE
feat(api): usecase to call the matching algorithm api (#633)

### DIFF
--- a/api/config.js
+++ b/api/config.js
@@ -51,6 +51,10 @@ const configuration = (function() {
       },
     },
     baseUrl: process.env.BASE_URL,
+    algorithm: {
+      enabled: process.env.ALGORITHM_ENABLED !== "false",
+      apiUrl: process.env.ALGORITHM_API_URL || "http://localhost:8000",
+    },
     swagger: {
       definition: {
         openapi: "3.0.0",
@@ -77,6 +81,8 @@ const configuration = (function() {
     config.email.enabled = false;
     config.email.testAccount = false;
     config.baseUrl = "http://localhost/#/";
+    config.algorithm.enabled = false;
+    config.algorithm.apiUrl = "http://localhost:8000";
   }
   return config;
 })();

--- a/api/sample.env
+++ b/api/sample.env
@@ -86,3 +86,10 @@ MAILING_PORT=465
 # Base url
 # Base url for email links and redirection from api to web site
 BASE_URL="http://localhost:5173/#/"
+
+# ---------------
+# Matching algorithm
+# Toggle the call to the kompagnon-algo API (set to false to skip it in development)
+ALGORITHM_ENABLED=true
+# Base url of the kompagnon-algo API used to match journeys
+ALGORITHM_API_URL="http://localhost:8000"

--- a/api/src/journeys/errors.js
+++ b/api/src/journeys/errors.js
@@ -54,4 +54,22 @@ class UserHasNoRole extends DomainError {
   }
 }
 
-export { AlreadyAccepted, AlreadyCancelled, AlreadyRejected, JourneyIsNotOfThisUser, JourneyNotFound, UserHasNoRole };
+/**
+ * Throw when the matching algorithm url is not configured
+ */
+class MatchingAlgorithmNotConfigured extends DomainError {
+  constructor() {
+    super("Matching algorithm api url is not configured", 500);
+  }
+}
+
+/**
+ * Throw when the matching algorithm answers with a non-ok status
+ */
+class MatchingAlgorithmRequestFailed extends DomainError {
+  constructor(status) {
+    super(`Matching algorithm request failed with status ${status}`, 502);
+  }
+}
+
+export { AlreadyAccepted, AlreadyCancelled, AlreadyRejected, JourneyIsNotOfThisUser, JourneyNotFound, MatchingAlgorithmNotConfigured, MatchingAlgorithmRequestFailed, UserHasNoRole };

--- a/api/src/journeys/infrastructure/matching-algorithm-api.js
+++ b/api/src/journeys/infrastructure/matching-algorithm-api.js
@@ -1,0 +1,45 @@
+import { config } from "../../../config.js";
+import { MatchingAlgorithmNotConfigured, MatchingAlgorithmRequestFailed } from "../errors.js";
+
+const MATCH_PATH = "/api/match";
+
+/**
+ * Roles expected by the kompagnon-algo match route.
+ * @readonly
+ * @enum {string}
+ */
+const MATCHING_ROLE = {
+  PASSENGER: "passenger",
+  COMPANION: "companion",
+};
+
+/**
+ * Calls the kompagnon-algo match route for a journey that has just been saved.
+ * The response is intentionally returned as-is and not exploited yet.
+ * @param {object} params - The match parameters.
+ * @param {number} params.journeyId - The id of the journey to match.
+ * @param {string} params.role - The role of the journey owner (see MATCHING_ROLE).
+ * @returns {Promise<object>} The match response from the algorithm API.
+ */
+async function requestJourneyMatch({ journeyId, role }) {
+  if (!config.algorithm.apiUrl) {
+    throw new MatchingAlgorithmNotConfigured();
+  }
+
+  const matchUrl = new URL(MATCH_PATH, config.algorithm.apiUrl).href;
+  const response = await fetch(matchUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ journey_id: journeyId, role }),
+  });
+
+  if (!response.ok) {
+    throw new MatchingAlgorithmRequestFailed(response.status);
+  }
+
+  return response.json();
+}
+
+export { MATCHING_ROLE, requestJourneyMatch };

--- a/api/src/journeys/usecases/call-matching-algorithm-usecase.js
+++ b/api/src/journeys/usecases/call-matching-algorithm-usecase.js
@@ -1,0 +1,29 @@
+import { config } from "../../../config.js";
+import { logger } from "../../../logger.js";
+import { requestJourneyMatch } from "../infrastructure/matching-algorithm-api.js";
+
+/**
+ * Calls the matching algorithm for a journey that has just been saved. The call
+ * is skipped when disabled (ALGORITHM_ENABLED=false) and is best-effort: a
+ * failure is logged but never breaks the journey recording. The answer is not
+ * exploited yet (handled in a future ticket).
+ * @param {object} params - The match parameters.
+ * @param {number} params.journeyId - The id of the journey to match.
+ * @param {string} params.role - The role of the journey owner (passenger or companion).
+ * @param {Function} matchRequester - The matching API client, injected for testing.
+ * @returns {Promise<object|undefined>} The match response, or undefined when skipped or failed.
+ */
+async function callMatchingAlgorithmUsecase({ journeyId, role }, matchRequester = requestJourneyMatch) {
+  if (!config.algorithm.enabled) {
+    return undefined;
+  }
+
+  try {
+    return await matchRequester({ journeyId, role });
+  } catch (error) {
+    logger.error({ err: error }, "Matching algorithm call failed");
+    return undefined;
+  }
+}
+
+export { callMatchingAlgorithmUsecase };

--- a/api/src/journeys/usecases/index.js
+++ b/api/src/journeys/usecases/index.js
@@ -1,5 +1,6 @@
 import { acceptFoundJourneyCompanionStatusUsecase } from "./accept-found-journey-companion-status-usecase.js";
 import { acceptFoundJourneyPassengerStatusUsecase } from "./accept-found-journey-passenger-status-usecase.js";
+import { callMatchingAlgorithmUsecase } from "./call-matching-algorithm-usecase.js";
 import { cancelFoundJourneyCompanionStatusUsecase } from "./cancel-found-journey-companion-status-usecase.js";
 import { cancelFoundJourneyPassengerStatusUsecase } from "./cancel-found-journey-passenger-status-usecase.js";
 import { getCompanionJourneyUsecase } from "./get-companion-journey-usecase.js";
@@ -10,15 +11,16 @@ import { rejectFoundJourneyCompanionStatusUsecase } from "./reject-found-journey
 import { rejectFoundJourneyPassengerStatusUsecase } from "./reject-found-journey-passenger-status-usecase.js";
 
 const usecases = {
+  acceptFoundJourneyCompanionStatusUsecase,
+  acceptFoundJourneyPassengerStatusUsecase,
+  callMatchingAlgorithmUsecase,
+  cancelFoundJourneyCompanionStatusUsecase,
+  cancelFoundJourneyPassengerStatusUsecase,
   getCompanionJourneyUsecase,
   getPassengerJourneyUsecase,
   recordCompanionJourneyUsecase,
   recordPassengerJourneyUsecase,
-  acceptFoundJourneyCompanionStatusUsecase,
-  cancelFoundJourneyCompanionStatusUsecase,
   rejectFoundJourneyCompanionStatusUsecase,
-  acceptFoundJourneyPassengerStatusUsecase,
-  cancelFoundJourneyPassengerStatusUsecase,
   rejectFoundJourneyPassengerStatusUsecase,
 };
 

--- a/api/src/journeys/usecases/record-companion-journey-usecase.js
+++ b/api/src/journeys/usecases/record-companion-journey-usecase.js
@@ -1,8 +1,12 @@
+import { MATCHING_ROLE } from "../infrastructure/matching-algorithm-api.js";
 import { saveJourney } from "../repositories/companion-users-repository.js";
+import { callMatchingAlgorithmUsecase } from "./call-matching-algorithm-usecase.js";
 import { recordJourneyUsecase } from "./record-journey-usecase.js";
 
 async function recordCompanionJourneyUsecase({ userId, departureTime, arrivalTime, departureAddress, arrivalAddress, departureLon = null, departureLat = null, arrivalLon = null, arrivalLat = null }) {
-  return await recordJourneyUsecase(saveJourney, { userId, departureTime, arrivalTime, departureAddress, arrivalAddress, departureLon, departureLat, arrivalLon, arrivalLat });
+  const recordedJourney = await recordJourneyUsecase(saveJourney, { userId, departureTime, arrivalTime, departureAddress, arrivalAddress, departureLon, departureLat, arrivalLon, arrivalLat });
+  await callMatchingAlgorithmUsecase({ journeyId: recordedJourney.journeyId, role: MATCHING_ROLE.COMPANION });
+  return recordedJourney;
 }
 
 export { recordCompanionJourneyUsecase };

--- a/api/src/journeys/usecases/record-passenger-journey-usecase.js
+++ b/api/src/journeys/usecases/record-passenger-journey-usecase.js
@@ -1,8 +1,12 @@
+import { MATCHING_ROLE } from "../infrastructure/matching-algorithm-api.js";
 import { saveJourney } from "../repositories/passenger-users-repository.js";
+import { callMatchingAlgorithmUsecase } from "./call-matching-algorithm-usecase.js";
 import { recordJourneyUsecase } from "./record-journey-usecase.js";
 
 async function recordPassengerJourneyUsecase({ userId, departureTime, arrivalTime, departureAddress, arrivalAddress, departureLon = null, departureLat = null, arrivalLon = null, arrivalLat = null }) {
-  return await recordJourneyUsecase(saveJourney, { userId, departureTime, arrivalTime, departureAddress, arrivalAddress, departureLon, departureLat, arrivalLon, arrivalLat });
+  const recordedJourney = await recordJourneyUsecase(saveJourney, { userId, departureTime, arrivalTime, departureAddress, arrivalAddress, departureLon, departureLat, arrivalLon, arrivalLat });
+  await callMatchingAlgorithmUsecase({ journeyId: recordedJourney.journeyId, role: MATCHING_ROLE.PASSENGER });
+  return recordedJourney;
 }
 
 export { recordPassengerJourneyUsecase };

--- a/api/tests/journeys/integration/usecases/call-matching-algorithm-usecase.test.js
+++ b/api/tests/journeys/integration/usecases/call-matching-algorithm-usecase.test.js
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { config } from "../../../../config.js";
+import { callMatchingAlgorithmUsecase } from "../../../../src/journeys/usecases/call-matching-algorithm-usecase.js";
+
+describe("Integration | Journeys | Usecases | Call matching algorithm", () => {
+  beforeEach(() => {
+    config.algorithm.enabled = true;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    config.algorithm.enabled = false;
+  });
+
+  it("should call the algo match route and return its answer when enabled", async () => {
+    // given
+    const matchResponse = { found_journey_ids: [1], message: "ok" };
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(matchResponse),
+    });
+
+    // when
+    const result = await callMatchingAlgorithmUsecase({ journeyId: 7, role: "passenger" });
+
+    // then
+    expect(fetchSpy).toHaveBeenCalledWith("http://localhost:8000/api/match", expect.objectContaining({
+      method: "POST",
+      body: JSON.stringify({ journey_id: 7, role: "passenger" }),
+    }));
+    expect(result).toEqual(matchResponse);
+  });
+
+  it("should skip the call when the algorithm is disabled", async () => {
+    // given
+    config.algorithm.enabled = false;
+    const fetchSpy = vi.spyOn(global, "fetch");
+
+    // when
+    const result = await callMatchingAlgorithmUsecase({ journeyId: 7, role: "passenger" });
+
+    // then
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(result).toBeUndefined();
+  });
+
+  it("should not throw and return undefined when the algorithm request fails", async () => {
+    // given
+    vi.spyOn(global, "fetch").mockResolvedValue({ ok: false, status: 502 });
+
+    // when
+    const result = await callMatchingAlgorithmUsecase({ journeyId: 7, role: "companion" });
+
+    // then
+    expect(result).toBeUndefined();
+  });
+});

--- a/api/tests/journeys/unit/infrastructure/matching-algorithm-api.test.js
+++ b/api/tests/journeys/unit/infrastructure/matching-algorithm-api.test.js
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { config } from "../../../../config.js";
+import { requestJourneyMatch } from "../../../../src/journeys/infrastructure/matching-algorithm-api.js";
+
+describe("Unit | Journeys | Infrastructure | Matching algorithm api", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should POST the journey id and role to the algo match route and return its answer", async () => {
+    // given
+    const matchResponse = { found_journey_ids: [], message: "no match" };
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(matchResponse),
+    });
+
+    // when
+    const result = await requestJourneyMatch({ journeyId: 7, role: "passenger" });
+
+    // then
+    expect(fetchSpy).toHaveBeenCalledWith("http://localhost:8000/api/match", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ journey_id: 7, role: "passenger" }),
+    });
+    expect(result).toEqual(matchResponse);
+  });
+
+  it("should throw when the algorithm responds with a non-ok status", async () => {
+    // given
+    vi.spyOn(global, "fetch").mockResolvedValue({ ok: false, status: 404 });
+
+    // when / then
+    await expect(requestJourneyMatch({ journeyId: 7, role: "companion" })).rejects.toThrow("status 404");
+  });
+
+  it("should throw a clear error when the algorithm base url is not configured", async () => {
+    // given
+    const originalUrl = config.algorithm.apiUrl;
+    config.algorithm.apiUrl = "";
+
+    // when / then
+    try {
+      await expect(requestJourneyMatch({ journeyId: 7, role: "passenger" })).rejects.toThrow("Matching algorithm api url is not configured");
+    } finally {
+      config.algorithm.apiUrl = originalUrl;
+    }
+  });
+});


### PR DESCRIPTION
Closes #633.

Adds the usecase that calls the kompagnon-algo matching API with the id of a journey that was just saved. Looking at the kompagnon-algo swagger, the match route is `POST /api/match` with `{ journey_id, role }` and returns `{ found_journey_ids, message }`. As stated in the ticket, the answer is not exploited yet — a later ticket will do that.

What's in here:
- `ALGORITHM_API_URL` env var (config.js + sample.env), defaulting to the algo's port (8000).
- `matching-algorithm-api.js`: HTTP client that POSTs `{ journey_id, role }` to `/api/match`, with a `MATCHING_ROLE` constant (passenger / companion). Throws on a non-ok response.
- `callMatchingAlgorithmUsecase({ journeyId, role })`: the usecase, with the client injectable for tests.

The usecase is standalone for now; wiring it into the journey recording flow is left for the follow-up ticket (the ticket only asks to create the usecase and explicitly defers using the response).

Tests: usecase (client mocked) and client (fetch mocked, success + non-ok). Full API suite green (166).